### PR TITLE
Fix phantomjs problem with non ssl3 sites

### DIFF
--- a/src/drivers/phantomjs/Dockerfile
+++ b/src/drivers/phantomjs/Dockerfile
@@ -26,4 +26,4 @@ RUN wappalyzer/bin/wappalyzer-links wappalyzer
 
 WORKDIR wappalyzer/src/drivers/phantomjs
 
-ENTRYPOINT ["/usr/local/phantomjs/bin/phantomjs", "--load-images=false", "--ignore-ssl-errors=yes", "driver.js"]
+ENTRYPOINT ["/usr/local/phantomjs/bin/phantomjs", "--load-images=false", "--ignore-ssl-errors=yes", "--ssl-protocol=any", "driver.js"]


### PR DESCRIPTION
By default phantoms JS use SSLv3 only:
`  --ssl-protocol=<val>                 Sets the SSL protocol (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')`
For this reason it doesn't work with non ssl3 sites like https://mail.ru.