### PR TITLE
Fix for outdated brand

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3720,12 +3720,12 @@
 			"implies": "PHP",
 			"website": "moodle.org"
 		},
-		"Moogo": {
+		"Kotisivukone": {
 			"cats": [
 				1
 			],
 			"script": "kotisivukone(?:\\.min)?\\.js",
-			"website": "www.moogo.com"
+			"website": "www.kotisivukone.fi"
 		},
 		"Motion-httpd": {
 			"cats": [


### PR DESCRIPTION
Moogo is discontinued. The CMS continues it's life under Kotisivukone brand