### PR TITLE
Check for `X-Powered-By: Craft CMS` header

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1240,7 +1240,8 @@
 				1
 			],
 			"headers": {
-				"Set-Cookie": "CraftSessionId="
+				"Set-Cookie": "CraftSessionId=",
+				"X-Powered-By": "Craft CMS"
 			},
 			"implies": "PHP",
 			"website": "buildwithcraft.com"


### PR DESCRIPTION
As of Craft 2.4, Craft will send this header by default.