### PR TITLE
Changes to LMS category expressions

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3738,10 +3738,7 @@
 				21
 			],
 			"env": "^moodle",
-			"headers": {
-				"Set-Cookie": "MoodleSession"
-			},
-			"html": "<img[^>]+moodlelogo",
+			"html": "^M.str\\s=\\s.*\"moodle\"",
 			"implies": "PHP",
 			"website": "moodle.org"
 		},

--- a/src/apps.json
+++ b/src/apps.json
@@ -3765,8 +3765,6 @@
 			],
 			"env": "^moodle$",
 			"html": "M\\.str = [^(moodle)]*\"moodle\"",
-			"html": "(<script|link)[^>]*mg-(core|plugins|templates)",
-			"html": "<link[^>]* href=[^>]+nv\\.d3(?:\\.min)?\\.css",
 			"implies": "PHP",
 			"website": "moodle.org"
 		},

--- a/src/apps.json
+++ b/src/apps.json
@@ -642,7 +642,7 @@
 				21
 			],
 			"meta": {
-				"copyright": ".*Blackboard Inc$"
+				"copyright": "Blackboard Inc$"
 			},
 			"website": "blackboard.com" 
 		},
@@ -895,7 +895,7 @@
 			"cats": [
 				21
 			],
-			"html": "id=\"registration_footer\".*Instructure",
+			"html": "&copy; 20\\d{2} <a href=\"www\\.instructure\\.com\">Instructure</a>",
 			"website": "instructure.com"
 		},
 		"Carbon Ads": {
@@ -3764,7 +3764,7 @@
 				21
 			],
 			"env": "^moodle",
-			"html": "^M.str\\s=\\s.*\"moodle\"",
+			"html": "^M.str\\s=\\s([^(moodle)])\"moodle\"\:",
 			"implies": "PHP",
 			"website": "moodle.org"
 		},

--- a/src/apps.json
+++ b/src/apps.json
@@ -3763,8 +3763,8 @@
 			"cats": [
 				21
 			],
-			"env": "^moodle",
-			"html": "^M.str\\s=\\s([^(moodle)])\"moodle\"\:",
+			"env": "^moodle$",
+			"html": "M\\.str\\s=\\s[^(moodle)]*\"moodle\"\:",
 			"implies": "PHP",
 			"website": "moodle.org"
 		},

--- a/src/apps.json
+++ b/src/apps.json
@@ -3764,7 +3764,9 @@
 				21
 			],
 			"env": "^moodle$",
-			"html": "M\\.str\\s=\\s[^(moodle)]*\"moodle\"\:",
+			"html": "M\\.str = [^(moodle)]*\"moodle\"",
+			"html": "(<script|link)[^>]*mg-(core|plugins|templates)",
+			"html": "<link[^>]* href=[^>]+nv\\.d3(?:\\.min)?\\.css",
 			"implies": "PHP",
 			"website": "moodle.org"
 		},

--- a/src/apps.json
+++ b/src/apps.json
@@ -637,6 +637,15 @@
 			"script": "bittads\\.com/js/bitt\\.js$",
 			"website": "bittads.com"
 		},
+        "Blackboard": {
+            "cats": [
+                21
+            ],
+			"meta": {
+				"copyright": "^.*Blackboard Inc$"
+			},
+            "website": "blackboard.com" 
+        },
 		"Blip.tv": {
 			"cats": [
 				14
@@ -882,6 +891,13 @@
 			],
 			"website": "www.canon.com"
 		},
+        "Canvas LMS": {
+            "cats": [
+                21
+            ],
+            "html": "id=\\"registration_footer\\".*Instructure",
+            "website": "instructure.com"
+        },
 		"Carbon Ads": {
 			"cats": [
 				36
@@ -1493,6 +1509,16 @@
 			"implies": "Django",
 			"website": "django-cms.org"
 		},
+        "Docebo": {
+            "cats": [
+                21
+            ],
+			"meta": {
+				"Copyright": "Docebo srl"
+			},
+            "implies": "PHP",
+            "website": "docebo.com"
+        },
 		"Dojo": {
 			"cats": [
 				12
@@ -4925,6 +4951,14 @@
 			},
 			"website": "saia-pcd.com"
 		},
+        "Sakai": {
+            "cats": [
+                21
+            ],
+			"html": "sakaiCopyrightInfo",
+            "implies": "Java",
+            "website": "sakaiproject.org" 
+        },
 		"Sarka-SPIP": {
 			"cats": [
 				1

--- a/src/apps.json
+++ b/src/apps.json
@@ -637,15 +637,15 @@
 			"script": "bittads\\.com/js/bitt\\.js$",
 			"website": "bittads.com"
 		},
-        "Blackboard": {
-            "cats": [
-                21
-            ],
+		"Blackboard": {
+			"cats": [
+				21
+			],
 			"meta": {
-				"copyright": "^.*Blackboard Inc$"
+				"copyright": ".*Blackboard Inc$"
 			},
-            "website": "blackboard.com" 
-        },
+			"website": "blackboard.com" 
+		},
 		"Blip.tv": {
 			"cats": [
 				14
@@ -891,13 +891,13 @@
 			],
 			"website": "www.canon.com"
 		},
-        "Canvas LMS": {
-            "cats": [
-                21
-            ],
-            "html": "id=\\"registration_footer\\".*Instructure",
-            "website": "instructure.com"
-        },
+		"Canvas LMS": {
+			"cats": [
+				21
+			],
+			"html": "id=\"registration_footer\".*Instructure",
+			"website": "instructure.com"
+		},
 		"Carbon Ads": {
 			"cats": [
 				36
@@ -1509,16 +1509,16 @@
 			"implies": "Django",
 			"website": "django-cms.org"
 		},
-        "Docebo": {
-            "cats": [
-                21
-            ],
+		"Docebo": {
+			"cats": [
+				21
+			],
 			"meta": {
 				"Copyright": "Docebo srl"
-			},
-            "implies": "PHP",
-            "website": "docebo.com"
-        },
+				},
+			"implies": "PHP",
+			"website": "docebo.com"
+		},
 		"Dojo": {
 			"cats": [
 				12
@@ -4951,14 +4951,14 @@
 			},
 			"website": "saia-pcd.com"
 		},
-        "Sakai": {
-            "cats": [
-                21
-            ],
+		"Sakai": {
+			"cats": [
+				21
+			],
 			"html": "sakaiCopyrightInfo",
-            "implies": "Java",
-            "website": "sakaiproject.org" 
-        },
+			"implies": "Java",
+			"website": "sakaiproject.org" 
+		},
 		"Sarka-SPIP": {
 			"cats": [
 				1


### PR DESCRIPTION
This change has to be verified. I have no clear idea of how to check that these will accurately match the corresponding pages.
In particular, I have modified the detector for Moodle sites, considering most of its traffic is registered as coming from http://support.godaddy.com/ and http://who.godaddy.com/ which are not even Moodle sites. This was due to a check on cookies headers (that might be validly maintained on subdomains of the same domain) which I have now removed. These should thus be spread between multiple subdomains now (hopefully), although it is possible the expression was just bogus and was generating visits for people simply going to godaddy... not sure
New detector expressions are less of an issue as they are new, but please review before merging to avoid one expression to consume a lot of resources or to check something undue.