### PR TITLE
Added 2 lines to make a "wappalyzer_npm" build folder 

### DIFF
--- a/bin/wappalyzer-build
+++ b/bin/wappalyzer-build
@@ -17,6 +17,10 @@ jsonlint -ist $'\t' $WAPPALYZER_ROOT/src/apps.json
 
 wappalyzer links
 
+# Npm Module
+mkdir -p $WAPPALYZER_ROOT/build/wappalyzer_npm/
+cp -R $WAPPALYZER_ROOT/src/drivers/npm/* $WAPPALYZER_ROOT/build/wappalyzer_npm/
+
 # Mozilla Firefox
 echo "Building Firefox driver..."
 


### PR DESCRIPTION
Added "NPM" to the build list. But all I'm doing is ``cp -R $WAPPALYZER_ROOT/src/drivers/npm/* $WAPPALYZER_ROOT/build/wappalyzer_npm/``. 

Once built you can publish with https://docs.npmjs.com/cli/publish