### PR TITLE
[TASK] Update Neos URL after split from TYPO3

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5702,7 +5702,7 @@
 				"TYPO3 Flow"
 			],
 			"url": "/neos/",
-			"website": "neos.typo3.org"
+			"website": "neos.io"
 		},
 		"Taiga": {
 			"cats": [


### PR DESCRIPTION
Neos has separated from the TYPO3 completely and now has it's own URL, funding, and more. **Make sure that the newly released Neos 2.0 is still being pickup up by your scripts.**

- https://typo3.org/news/article/typo3-project-focuses-on-typo3-cms-neos-to-start-its-own-community/
- https://typo3.org/news/article/this-week-in-typo3-2015-week-25/