### PR TITLE
Fixed Doxygen URL

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1639,7 +1639,7 @@
 			"meta": {
 				"generator": "Doxygen ([\\d.]+)\\;version:\\1"
 			},
-			"website": "stack.nl/~dimitri/doxygen"
+			"website": "www.stack.nl/~dimitri/doxygen/"
 		},
 		"DreamWeaver": {
 			"cats": [


### PR DESCRIPTION
The domain name must be prefixed with "www.".