### PR TITLE
Fixed dead link Backbone.js

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -586,7 +586,7 @@
 			"env": "^Backbone$",
 			"implies": "Underscore.js",
 			"script": "backbone.*\\.js",
-			"website": "documentcloud.github.com/backbone"
+			"website": "backbonejs.org"
 		},
 		"Backdrop": {
 			"cats": [


### PR DESCRIPTION
The [old](http://documentcloud.github.com/backbone) website link of Backbone.js is dead. Changed to new URL: backbonejs.org