### PR TITLE
Validate capture groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4.1.0"
 sudo: required
 before_install:
   - export WAPPALYZER_ROOT=$TRAVIS_BUILD_DIR

--- a/bin/wappalyzer-validate-regex
+++ b/bin/wappalyzer-validate-regex
@@ -25,12 +25,43 @@ for ( app in json.apps ) {
 			patterns.forEach(function(pattern) {
 				var
 					attrs = pattern.split('\\;'),
-					regex = '/' + attrs.shift().replace('/', '\/') + '/';
+					regex = '/' + attrs.shift().replace('/', '\/') + '/',
+					version = attrs.find( function (attr){
+						return attr.indexOf('version:')===0;
+						} ),
+					amountOfCaptureGroups,
+					captureGroupsNeeded,
+					amountOfCaptureGroupsNeeded,
+					highestBackReference;
 
 				//Check if the pattern is a valid RegExp
 				//Note: unlike when used in Wappalyzer, the modifier i isn't added here
 				new RegExp(regex);
 
+				//Actual amount of capture groups
+				amountOfCaptureGroups = ''.match(new RegExp('(?:'+pattern+')?')).length - 1;
+
+				//Capture groups of which the result is used
+				captureGroupsNeeded = version ? (version.match(/\\\d/g) || []).filter( function(value, index, self){
+					return self.indexOf(value) === index;
+				}).map( function(value){//Because Math.max needs the integers only
+					return parseInt(value.charAt(1), 10);//Will only work if backreferences cannot be any longer than a single digit
+				}) : [];
+
+				//Amount of capture groups needed
+				amountOfCaptureGroupsNeeded = captureGroupsNeeded.length;
+
+				//Highest back reference number used
+				highestBackReference = Math.max.apply(null, captureGroupsNeeded);
+
+				//Report error
+				if(amountOfCaptureGroups > amountOfCaptureGroupsNeeded) {
+					throw new Error('The pattern uses more capture groups than needed. Use non-capturing roups where appropriate.\n' + app + ': ' + type + ': ' + pattern);
+				}else if(amountOfCaptureGroups < amountOfCaptureGroupsNeeded){
+					throw new Error('The version string references more capture groups than there are in the pattern! Remove any incorrect back references from the version string and/or add the missing capture groups to the pattern.\n' + app + ': ' + type + ': ' + pattern);
+				} else if(highestBackReference > amountOfCaptureGroups){
+					throw new Error('The version string references one or more capture groups whose index is higher than the amount of capture groups in the pattern. Please use the correct index instead of \\\\'+highestBackReference+'.\n' + app + ': ' + type + ': ' + pattern);
+				}
 
 				if ( /^\/(?:\^\$|\.\+|\.\*)\/$/.test(regex) )  {
 					throw new Error('Pattern should be replaced with empty string.\n' + app + ': ' + type + ': ' + pattern);


### PR DESCRIPTION
Detect when a version string has too little, too much or the wrong capture
groups.

Upgrade Node.JS to 4.10 because a recent version is required for the new
code.

I probably spent _way_ too much time on this&hellip;