### PR TITLE
Optimize headers parsing

### DIFF
--- a/src/drivers/php/Wappalyzer.php
+++ b/src/drivers/php/Wappalyzer.php
@@ -133,11 +133,11 @@ class Wappalyzer
 		$headers = trim(substr($response, 0, $headerSize));
 		$headers = preg_split('/^\s*$/m', $headers);
 		$headers = end($headers);
-		$lines = array_slice(explode("\r\n", $headers), 1);
+		$lines = array_slice(explode("\n", $headers), 1);
 
 		foreach ( $lines as $line ) {
 			if ( strpos(trim($line), ': ') !== false ) {
-				list($key, $value) = explode(': ', $line);
+				list($key, $value) = explode(': ', trim($line, "\r"));
 
 				$result->headers[strtolower($key)] = $value;
 			}


### PR DESCRIPTION
The server can not follow the RFC and use \n as separator instead \r\n