### PR TITLE
Updated website URL WP-Super-Cache

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -6630,7 +6630,7 @@
 			],
 			"html": "<!--[^>]+WP-Super-Cache",
 			"implies": "WordPress",
-			"website": "ocaoimh.ie/wp-super-cache/"
+			"website": "z9.io/wp-super-cache/"
 		},
 		"Wowza Media Server": {
 			"cats": [


### PR DESCRIPTION
Updated website URL WP-Super-Cache. ocaoimh.ie/wp-super-cache/ is redirecting to new URL z9.io/wp-super-cache/, changed it just in case they remove their old domain.