### PR TITLE
Add support for svg icons in drivers

### DIFF
--- a/bin/wappalyzer-links
+++ b/bin/wappalyzer-links
@@ -30,19 +30,23 @@ echo "Creating hard links..."
 ln -f $path/wappalyzer.js $path/drivers/firefox/lib
 ln -f $path/apps.json     $path/drivers/firefox/data
 ln -f $path/icons/*.png   $path/drivers/firefox/data/images/icons
+ln -f $path/icons/*.svg   $path/drivers/firefox/data/images/icons
 ln -f $path/utils/*.js    $path/drivers/firefox/data/js
 
 ln -f $path/wappalyzer.js $path/drivers/chrome/js
 ln -f $path/apps.json     $path/drivers/chrome
 ln -f $path/icons/*.png   $path/drivers/chrome/images/icons
+ln -f $path/icons/*.svg   $path/drivers/chrome/images/icons
 ln -f $path/utils/*.js    $path/drivers/chrome/js
 
 ln -f $path/wappalyzer.js $path/drivers/bookmarklet/js
 ln -f $path/icons/*.png   $path/drivers/bookmarklet/images/icons
+ln -f $path/icons/*.svg   $path/drivers/bookmarklet/images/icons
 
 ln -f $path/wappalyzer.js $path/drivers/html/js
 ln -f $path/apps.json     $path/drivers/html
 ln -f $path/icons/*.png   $path/drivers/html/images/icons
+ln -f $path/icons/*.svg   $path/drivers/html/images/icons
 
 ln -f $path/wappalyzer.js $path/drivers/php/js
 ln -f $path/apps.json     $path/drivers/php

--- a/src/drivers/bookmarklet/.gitignore
+++ b/src/drivers/bookmarklet/.gitignore
@@ -1,3 +1,4 @@
 images/icons/*.png
+images/icons/*.svg
 js/wappalyzer.js
 js/apps.js

--- a/src/drivers/bookmarklet/js/driver.js
+++ b/src/drivers/bookmarklet/js/driver.js
@@ -147,7 +147,7 @@
 						'<div class="wappalyzer-app' + ( first ? ' wappalyzer-first' : '' ) + '">' +
 							'<a target="_blank" class="wappalyzer-application" href="' + w.config.websiteURL + 'applications/' + app.toLowerCase().replace(/ /g, '-').replace(/[^a-z0-9-]/g, '') + '">' +
 								'<strong>' +
-									'<img src="' + w.config.websiteURL + 'bookmarklet/images/icons/' + app + '.png" width="16" height="16"/> ' + app +
+									'<img src="' + w.config.websiteURL + 'bookmarklet/images/icons/' + w.apps[app].icon + '" width="16" height="16"/> ' + app +
 								'</strong>' +
 							'</a>'
 							;

--- a/src/drivers/chrome/.gitignore
+++ b/src/drivers/chrome/.gitignore
@@ -1,4 +1,5 @@
 apps.json
 images/icons/*.png
+images/icons/*.svg
 js/wappalyzer.js
 js/iframe.js

--- a/src/drivers/chrome/js/driver.js
+++ b/src/drivers/chrome/js/driver.js
@@ -193,7 +193,7 @@
 					for ( appName in w.detected[url] ) {
 						w.apps[appName].cats.forEach(function(cat) {
 							if ( cat == match && !found ) {
-								chrome.pageAction.setIcon({ tabId: tab.id, path: 'images/icons/' + appName + '.png' });
+								chrome.pageAction.setIcon({ tabId: tab.id, path: 'images/icons/' + w.apps[appName].icon });
 
 								found = true;
 							}

--- a/src/drivers/chrome/js/popup.js
+++ b/src/drivers/chrome/js/popup.js
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', function() {
 							html =
 								'<div class="detected-app">' +
 									'<a target="_blank" href="https://wappalyzer.com/applications/' + appName.toLowerCase().replace(/ /g, '-').replace(/[^\w-]/g, '') + '?pk_campaign=chrome&pk_kwd=popup">' +
-										'<img src="images/icons/' + appName + '.png"/>' +
+										'<img src="images/icons/' + response.apps[appName].icon + '"/>' +
 										'<span class="label"><span class="name">' + appName + '</span>' + ( version ? ' ' + version : '' ) + ( confidence < 100 ? ' (' + confidence + '% sure)' : '' ) + '</span>' +
 									'</a>';
 

--- a/src/drivers/firefox/.gitignore
+++ b/src/drivers/firefox/.gitignore
@@ -1,4 +1,5 @@
 data/apps.json
 data/images/icons/*.png
+data/images/icons/*.svg
 data/js/iframe.js
 lib/wappalyzer.js

--- a/src/drivers/firefox/data/js/panel.js
+++ b/src/drivers/firefox/data/js/panel.js
@@ -35,7 +35,7 @@
 					});
 				}(appName));
 
-				img.setAttribute('src',    'images/icons/' + appName + '.png');
+				img.setAttribute('src',    'images/icons/' + message.apps[appName].icon);
 				img.setAttribute('height', '16');
 				img.setAttribute('width',  '16');
 

--- a/src/drivers/firefox/driver.js
+++ b/src/drivers/firefox/driver.js
@@ -249,7 +249,7 @@
 	};
 
 	Button.prototype.setIcon = function(appName) {
-		var url = typeof appName === 'undefined' ? './images/icon32.png' : './images/icons/' + appName + '.png';
+		var url = typeof appName === 'undefined' ? './images/icon32.png' : './images/icons/' + w.apps[appName].icon;
 
 		this.button.icon = url;
 	};
@@ -303,7 +303,7 @@
 	UrlBar.prototype.addIcon = function(appName) {
 		var
 			icon = this.document.createElement('image'),
-			url = typeof appName === 'undefined' ? 'images/icon32.png' : 'images/icons/' + appName + '.png',
+			url = typeof appName === 'undefined' ? 'images/icon32.png' : 'images/icons/' + w.apps[appName].icon,
 			tooltipText = ( typeof appName !== 'undefined' ? appName + ' - ' + require('sdk/l10n').get('clickForDetails') + ' - ' : '' ) + require('sdk/l10n').get('name');
 
 		icon.setAttribute('src', require('sdk/self').data.url(url));

--- a/src/drivers/html/.gitignore
+++ b/src/drivers/html/.gitignore
@@ -1,3 +1,4 @@
 apps.json
 images/icons/*.png
+images/icons/*.svg
 js/wappalyzer.js

--- a/src/drivers/html/js/driver.js
+++ b/src/drivers/html/js/driver.js
@@ -51,7 +51,7 @@
 			document.getElementById('apps').innerHTML = '';
 
 			for ( app in w.detected[url] ) {
-				document.getElementById('apps').innerHTML += '<img src="images/icons/' + app + '.png" width="16" height="16"/> ' + app + '<br/>';
+				document.getElementById('apps').innerHTML += '<img src="images/icons/' + w.apps[app].icon + '" width="16" height="16"/> ' + app + '<br/>';
 			};
 		},
 


### PR DESCRIPTION
This adds support for svg icons in following drivers:
* Mozilla Firefox
* Google Chrome
* Bookmarklet
* HTML

Works in address bar and popups.