### PR TITLE
Lower confidence for all basket.js patterns

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -7842,8 +7842,8 @@
       "cats": [
         12
       ],
-      "env": "^basket$",
-      "script": "basket.*\\.js",
+      "env": "^basket$\\;confidence:20",
+      "script": "basket.*\\.js\\;confidence:10",
       "website": "addyosmani.github.io/basket.js/",
       "icon": "basket.js.png"
     },


### PR DESCRIPTION
The patterns for basket.js are quite generic and match at a lot of sites that aren't using this script. The confidence should be lower.