### PR TITLE
Re-add version detection for Arastta

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -508,7 +508,8 @@
       ],
       "excludes": "OpenCart",
       "headers": {
-        "X-Arastta": ""
+        "Arastta": "(.*)\\;version:\\1",
+        "X-Arastta": "\\;version:1.2.1+"
       },
       "html": "Powered by <a [^>]*href=\"https?://(?:www\\.)?arastta\\.org[^>]+>Arastta",
       "implies": "PHP",


### PR DESCRIPTION
Version information in the headers was removed in version 1.2.1, but not
all websites are using this version. Additionally, an empty "X-Arastta"
header implies Arastta 1.2.1+ so detection was added for this as well.