### PR TITLE
Respect "Show upgrade message" option in Chrome

### DIFF
--- a/src/drivers/chrome/js/driver.js
+++ b/src/drivers/chrome/js/driver.js
@@ -55,7 +55,7 @@
 					for ( option in defaults ) {
 						localStorage[option] = defaults[option];
 					}
-				} else if ( version !== localStorage['version'] && localStorage['upgradeMessage'] ) {
+				} else if ( version !== localStorage['version'] && parseInt(localStorage['upgradeMessage'], 10) ) {
 					upgraded = true;
 				}
 


### PR DESCRIPTION
Local Storage saves everything as strings: `"0"` is not falsey, `0` is.

Until now Chrome always opened a tab when Wappalizer updated, regardless of that option.