### PR TITLE
Update IP.Board/IPS Suite detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3159,7 +3159,7 @@
 			"cats": [
 				2
 			],
-			"env": "^(?:IPBoard$|ipb_var)",
+			"env": "^(?:IPBoard$|ipb_var|ipsSettings)",
 			"html": "<link[^>]+ipb_[^>]+\\.css",
 			"icon": "IPB.png",
 			"script": "jscripts/ips_",


### PR DESCRIPTION
IPB (now IPS Suite) version 4 doesn't use the global "IPBoard" object.