### PR TITLE
Fix Underscore.js URL

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -7163,7 +7163,7 @@
 			],
 			"icon": "Underscore.js.png",
 			"script": "underscore.*\\.js",
-			"website": "documentcloud.github.com/underscore"
+			"website": "underscorejs.org"
 		},
 		"UserRules": {
 			"cats": [


### PR DESCRIPTION
Fix [old](http://documentcloud.github.com/underscore) dead link to the [new](http://underscorejs.org/) one.
As seen on documentcloud.org/opensource.