### PR TITLE
Added magento2 support

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -4094,17 +4094,21 @@
 		},
 		"Magento": {
 			"cats": [
-				6
+			  6
 			],
-			"env": "^(?:Mage|VarienForm)$",
+			"env": [
+			  "^(?:Mage|VarienForm)$"
+			],
 			"headers": {
-				"Set-Cookie": "frontend=\\;confidence:50"
+			  "Set-Cookie": "frontend=\\;confidence:50"
 			},
+			"html": "<script [^>]*type=\"[^\"]+text/x-magento-init\\;version:\\2",
 			"icon": "Magento.png",
 			"implies": "PHP",
 			"script": [
-				"js/mage",
-				"skin/frontend/(?:default|(enterprise))\\;version:\\1?Enterprise:Community"
+			  "js/mage",
+			  "skin/frontend/(?:default|(enterprise))\\;version:\\1?Enterprise:Community",
+			  "static/_requirejs\\;confidence:50\\;version:\\2"
 			],
 			"website": "www.magentocommerce.com"
 		},

--- a/src/apps.json
+++ b/src/apps.json
@@ -4103,16 +4103,16 @@
 			  "Set-Cookie": "frontend=\\;confidence:50"
 			},
 			"html": [
-				"<script [^>]+data-requiremodule=\"mage/\\;version:\\2",
-				"<script [^>]+data-requiremodule=\"Magento_\\;version:\\2"
+				"<script [^>]+data-requiremodule=\"mage/\\;version:2",
+				"<script [^>]+data-requiremodule=\"Magento_\\;version:2"
 			],
 			"icon": "Magento.png",
 			"implies": "PHP",
 			"script": [
 			  	"js/mage",
 			  	"skin/frontend/(?:default|(enterprise))\\;version:\\1?Enterprise:Community",
-				"static/_requirejs\\;confidence:50\\;version:\\2",
-				"static/frontend\\;confidence:20\\;version:\\2"
+				"static/_requirejs\\;confidence:50\\;version:2",
+				"static/frontend\\;confidence:20\\;version:2"
 			],
 			"website": "www.magentocommerce.com"
 		},

--- a/src/apps.json
+++ b/src/apps.json
@@ -4102,13 +4102,17 @@
 			"headers": {
 			  "Set-Cookie": "frontend=\\;confidence:50"
 			},
-			"html": "<script [^>]*type=\"[^\"]+text/x-magento-init\\;version:\\2",
+			"html": [
+				"<script [^>]+data-requiremodule=\"mage/\\;version:\\2",
+				"<script [^>]+data-requiremodule=\"Magento_\\;version:\\2"
+			],
 			"icon": "Magento.png",
 			"implies": "PHP",
 			"script": [
-			  "js/mage",
-			  "skin/frontend/(?:default|(enterprise))\\;version:\\1?Enterprise:Community",
-			  "static/_requirejs\\;confidence:50\\;version:\\2"
+			  	"js/mage",
+			  	"skin/frontend/(?:default|(enterprise))\\;version:\\1?Enterprise:Community",
+				"static/_requirejs\\;confidence:50\\;version:\\2",
+				"static/frontend\\;confidence:20\\;version:\\2"
 			],
 			"website": "www.magentocommerce.com"
 		},


### PR DESCRIPTION
Hi, I just added 2 regexes to support Magento 2.

The first one is in the html node and looks for `<script type="text/x-magento-init">` the regex seems broken so would appreciate if anyone could take a look at it . This would then be the leading check for Magento 2 ( It's unique.. what's more to say ;-) ) 

The second checks for `static/_requirejs` in script tags, which is kind of unique to Magento 2 (haven't seen it before) but I don't think it should be the leading check. So I added it at 50% confidence.

We could create a third check which looks for `static/frontend` but I find that way too generic. So we might add it at 20% or lower.