### PR TITLE
Minor fix on Hippo CMS detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3040,7 +3040,7 @@
 			"cats": [
 				1
 			],
-			"html": " <[^>]+/binaries/(?:[^/]+/)*content/gallery/",
+			"html": "<[^>]+/binaries/(?:[^/]+/)*content/gallery/",
 			"icon": "Hippo.png",
 			"website": "onehippo.org"
 		},


### PR DESCRIPTION
Hippo CMS rexex extra space caused to miss out on CMS detection if the space is missing before the html tag.