### PR TITLE
Remove version number from Arastta e-Commerce

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -587,7 +587,7 @@
 			"excludes": "OpenCart",
 			"headers": {
 				"Arastta": "(.*)\\;version:\\1",
-				"X-Arastta": "\\;version:1.2.1+"
+				"X-Arastta": ""
 			},
 			"html": "Powered by <a [^>]*href=\"https?://(?:www\\.)?arastta\\.org[^>]+>Arastta",
 			"icon": "Arastta.png",


### PR DESCRIPTION
It always shows "Arastta 1.2.1+", after this change, it shows only "Arastta" if Arastta version is greater than 1.2.1