### PR TITLE
Detect PyroCMS v2.*

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5583,7 +5583,8 @@
 				1
 			],
 			"headers": {
-				"X-Streams-Distribution": "PyroCMS"
+				"X-Streams-Distribution": "PyroCMS",
+				"Set-Cookie": "pyrocms"
 			},
 			"icon": "PyroCMS.png",
 			"implies": "Laravel",


### PR DESCRIPTION
If I am understanding this correctly, this will match cookies named `*pyrocms*` which is how v2.* signals itself.