### PR TITLE
Use headers instead of whole response (npm driver)

### DIFF
--- a/src/drivers/npm/index.js
+++ b/src/drivers/npm/index.js
@@ -29,7 +29,7 @@ exports.detectFromHTML = function(options, data, cb) {
 /**
 * Do a actual request for the body & headers, then
 * run through detection
-**/ 
+**/
 exports.detectFromUrl = function(options, cb) {
 
 	// ensure options and url were
@@ -59,7 +59,7 @@ exports.detectFromUrl = function(options, cb) {
 				exports.detect(options, data, cb);
 
 			}
-		
+
 		});
 
 	}
@@ -71,7 +71,7 @@ function getHTMLFromUrl(url, cb) {
 			var data = {
 				html: body,
 				url: url,
-				headers: response
+				headers: response.headers
 			};
 			cb(null, data);
 		} else {


### PR DESCRIPTION
Using the actual header-data allows to detect nginx, apache, etc. correctly now.