### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ which is managed by Vagrant.
 Running this environment is optional but recommended as it provides some helpful tools.
 
 First, install [Docker](https://www.docker.com/) and [Vagrant](https://www.vagrantup.com/)
-on your system.
+on your system. [VirtualBox](https://www.virtualbox.org/) might be needed as well.
 
 Clone the Wappalyzer repository and open the newly created directory in a
 terminal. Run `vagrant up` to start the environment.


### PR DESCRIPTION
On my machine (OSX 10.12.1, Docker 1.12.3, Vagrant 1.9.0), I received the error below when running 'vagrant up' until I installed VirtualBox, even though I already had Docker installed.  Is it normal to need VirtualBox installed?

Error Message:
```
No usable default provider could be found for your system.

Vagrant relies on interactions with 3rd party systems, known as
"providers", to provide Vagrant with resources to run development
environments. Examples are VirtualBox, VMware, Hyper-V.

The easiest solution to this message is to install VirtualBox, which
is available for free on all major platforms.

If you believe you already have a provider available, make sure it
is properly installed and configured. You can see more details about
why a particular provider isn't working by forcing usage with
`vagrant up --provider=PROVIDER`, which should give you a more specific
error message for that particular provider.
```