### PR TITLE
Add YUI library regex with version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8213,8 +8213,11 @@
 			],
 			"env": "^YAHOO$",
 			"icon": "YUI.png",
-			"script": "(?:/yui/|yui\\.yahooapis\\.com)",
-			"website": "yuilibrary.com"
+			"script": [
+                "(?:/yui/|yui\\.yahooapis\\.com)",
+                "xregexp(?:(yuilib)\\?(\/|\\)(([0-9]+\.)*[0-9]+))\\;version:\\3"
+                ],
+		    "website": "yuilibrary.com"
 		},
 		"YUI Doc": {
 			"cats": [


### PR DESCRIPTION
Moodle is using YUI and apparently it's not detected properly. Haven't tested the regex in Wappalyzer, because didn't have time to build the dev env, so please give it a try before merging.

