### PR TITLE
Ensure regexes are applied to multi-value headers.

### DIFF
--- a/src/wappalyzer.js
+++ b/src/wappalyzer.js
@@ -351,8 +351,16 @@ var wappalyzer = (function() {
 
 							for ( header in w.apps[app].headers ) {
 								parse(w.apps[app][type][header]).forEach(function(pattern) {
-									if ( typeof data[type][header.toLowerCase()] === 'string' && pattern.regex.test(data[type][header.toLowerCase()]) ) {
-										apps[app].setDetected(pattern, type, data[type][header.toLowerCase()], header);
+									if ( data[type][header.toLowerCase()] instanceof Array ) {
+										data[type][header.toLowerCase()].forEach(function(el) {
+											if ( typeof el === 'string' && pattern.regex.test(el) ) {
+												apps[app].setDetected(pattern, type, data[type][header.toLowerCase()], header);
+											}
+										});
+									} else {
+											if ( typeof data[type][header.toLowerCase()] === 'string' && pattern.regex.test(data[type][header.toLowerCase()]) ) {
+												apps[app].setDetected(pattern, type, data[type][header.toLowerCase()], header);
+											}
 									}
 
 									profiler.checkPoint(app, type, pattern.regex);


### PR DESCRIPTION
Wappalyzer is currently unable to properly inspect cookies inside the ```Set-Cookie``` header.

According to my tests, this issue manifests itself on the chrome and nodejs drivers. The Firefox and phantomjs drivers seem to be working as expected.

The following in an example output from the nodejs driver.

Example ```response.headers```:

```javascript
{ server: 'nginx/1.10.0 (Ubuntu)',
  date: 'Wed, 07 Dec 2016 13:34:05 GMT',
  'content-type': 'text/html; charset=UTF-8',
  'transfer-encoding': 'chunked',
  connection: 'close',
  vary: 'Accept-Encoding',
  'set-cookie': [ 'PHPSESSID=i6v6oqfmvj90h4st7bb0442b21; path=/' ],
  expires: 'Thu, 19 Nov 1981 08:52:00 GMT',
  'cache-control': 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0',
  pragma: 'no-cache' }
```

The PHPSESSID cookie should match the following regex in ```apps.json```:

```json
                        "headers": {
                                "Server": "php/?([\\d.]+)?\\;confidence:40\\;version:\\1",
                                "Set-Cookie": "PHPSESSID",
                                "X-Powered-By": "php/?([\\d.]+)?\\;confidence:40\\;version:\\1"
                        },
```

However, due to the check in https://github.com/AliasIO/Wappalyzer/blob/0bff623f17c6dddb4a64a7e36b5ff223ef17134d/src/wappalyzer.js#L354

Any multi-valued header will not be properly checked, as is the case of the 'Set-Cookie' header.

This commit fixes that.

