### PR TITLE
Use `property` as `meta` key too

### DIFF
--- a/src/wappalyzer.js
+++ b/src/wappalyzer.js
@@ -329,7 +329,7 @@ var wappalyzer = (function() {
 								for ( meta in w.apps[app][type] ) {
 									profiler.checkPoint(app, type, regexMeta);
 
-									if ( new RegExp('name=["\']' + meta + '["\']', 'i').test(match) ) {
+									if ( new RegExp('(name|property)=["\']' + meta + '["\']', 'i').test(match) ) {
 										content = match.toString().match(/content=("|')([^"']+)("|')/i);
 
 										parse(w.apps[app].meta[meta]).forEach(function(pattern) {


### PR DESCRIPTION
Currently, only `name` is considered as a valid key for <meta>,
but more and more website, trying to be mobile-friendly,
are using <meta> tags without `name`, but with a `property`
instead. This commit changes this behaviour.

This idea emerged from [this MR](https://github.com/AliasIO/Wappalyzer/pull/1321).