### PR TITLE
Fix #1325 - BigCommerce is wrongly detected

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -822,10 +822,9 @@
 			"cats": [
 				6
 			],
-			"env": "^compareProducts$",
-			"html": "<link href=[^>]+cdn\\d+\\.bigcommerce\\.com/v",
+			"html": "<link href=[^>]+cdn\\d+\\.bigcommerce\\.com/",
 			"icon": "Bigcommerce.png",
-			"script": "cdn\\d+\\.bigcommerce\\.com/v",
+			"script": "cdn\\d+\\.bigcommerce\\.com/",
 			"url": "mybigcommerce\\.com",
 			"website": "www.bigcommerce.com"
 		},


### PR DESCRIPTION
Remove the "env" property that could incorrectly match a function in the global scope. Removed the trailing 'v' from the "script" and "html" entries that looks for the BigCommerce CDN paths since they can begin with letters other than 'v' like 's' in the to examples below.

Check against the following URLs :
https://shopmonarch.averydennison.com/
http://shop.panthers.com/