### PR TITLE
Fix anonymous reports option in Chrome

### DIFF
--- a/src/drivers/chrome/js/driver.js
+++ b/src/drivers/chrome/js/driver.js
@@ -217,7 +217,7 @@
 		 * Anonymously track detected applications for research purposes
 		 */
 		ping: function() {
-			if ( Object.keys(w.ping.hostnames).length && localStorage['tracking'] ) {
+			if ( Object.keys(w.ping.hostnames).length && parseInt(localStorage['tracking'], 10) ) {
 				w.driver.post('http://ping.wappalyzer.com/ping/v2/', w.ping);
 
 				w.log('w.driver.ping: ' + JSON.stringify(w.ping));


### PR DESCRIPTION
Convert string `'0'` to number `0`, see https://github.com/AliasIO/Wappalyzer/pull/1050