### PR TITLE
Improve a bit maxCDN detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -4389,7 +4389,8 @@
 				31
 			],
 			"headers": {
-				"Server": "NetDNA"
+				"Server": "^NetDNA",
+				"X-CDN-Forward": "^maxcdn$"
 			},
 			"icon": "MaxCDN.png",
 			"website": "www.maxcdn.com"


### PR DESCRIPTION
- Speed up a regexp by adding `^`
- Add a header

This can be tested [here](http://www.lequipe.fr/)