### PR TITLE
Improve detection for Brother devices

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -926,6 +926,10 @@
 			"cats": [
 				40
 			],
+			"html": [
+				"(?:<!--|<BR>)Copyright\\(C\\) [\\d-]+ Brother Industries",
+				"<TITLE>\n\\s*BROTHER "
+			],
 			"icon": "Brother.png",
 			"website": "www.brother.com"
 		},


### PR DESCRIPTION
Since those devices are printers that shouldn't be exposed on the
internet, I don't think that I should link webpages to test those rules
;)

Please find [attached](https://github.com/AliasIO/Wappalyzer/files/766757/brother.html.zip) a `curl -i $HOSTNAME` of a valid printer.



