### PR TITLE
Improve Bootstrap detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -7537,7 +7537,7 @@
 			"html": [
 				"<style>/\\*!\\* Bootstrap v(\\d\\.\\d\\.\\d)\\;version:\\1",
 				"<link[^>]+?href=\"[^\"]+bootstrap(?:\\.min)?\\.css",
-				"<div [^>]*class=\"[^\"]*col-(?:xs|sm|md|lg)-\\d{1,2}"
+				"<div[^>]+class=\"[^\"]*col-(?:xs|sm|md|lg)-\\d{1,2}"
 			],
 			"icon": "Twitter Bootstrap.png",
 			"script": "(?:twitter\\.github\\.com/bootstrap|bootstrap(?:\\.js|\\.min\\.js))",


### PR DESCRIPTION
This PR improves upon bootstrap detection by including an edge case.

The earlier regex was unable to detect bootstrap if the `<div` was followed by a tab. This PR fixes this issue.