### PR TITLE
Fix phantomjs driver loading wappalyzer.js

### DIFF
--- a/src/drivers/phantomjs/driver.js
+++ b/src/drivers/phantomjs/driver.js
@@ -10,10 +10,13 @@
 		quiet           = false; // Don't output errors
 
 	try {
-		// Working directory
-		scriptDir = scriptPath.split('/'); scriptDir.pop(); scriptDir = scriptDir.join('/');
+		var fs = require('fs');
+		if (!fs.isFile(fs.workingDirectory + '/wappalyzer.js')){
+			// Working directory
+			scriptDir = scriptPath.split('/'); scriptDir.pop(); scriptDir = scriptDir.join('/');
 
-		require('fs').changeWorkingDirectory(scriptDir);
+			fs.changeWorkingDirectory(scriptDir);
+		}
 
 		require('system').args.forEach(function(arg, i) {
 			var arr = /^(--[^=]+)=(.+)$/.exec(arg);
@@ -48,7 +51,7 @@
 		}
 
 		if ( !phantom.injectJs('wappalyzer.js') ) {
-			throw new Error('Unable to open file js/wappalyzer.js');
+			throw new Error('Unable to open file ' + fs.workingDirectory + '/wappalyzer.js');
 		}
 
 		wappalyzer.driver = {
@@ -210,9 +213,13 @@
 
 		wappalyzer.init();
 	} catch ( e ) {
-		wappalyzer.log(e, 'error');
+		if (typeof wappalyzer !== 'undefined'){
+			wappalyzer.log(e, 'error');
 
-		wappalyzer.driver.sendResponse();
+			wappalyzer.driver.sendResponse();
+		} else {
+			require('system').stderr.writeLine(e);
+		}
 
 		phantom.exit(1);
 	}


### PR DESCRIPTION
Fix for phantomjs driver to first look if wappalyzer.js exists in the current working directory before changing it to the driver's directory as it wasn't possible to run phantomjs driver directly from cloned repository without modifications due to missing files (e.g. wappalyzer.js doesn't exists by default in the driver directory).

Also logs errors to stderr if wappalyzer wasn't initialized due to injection error as driver would otherwise fail & crash