### PR TITLE
Improve a bit php detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5625,9 +5625,9 @@
 				27
 			],
 			"headers": {
-				"Server": "php/?([\\d.]+)?\\;confidence:40\\;version:\\1",
+				"Server": "(?:php|PHP)/?([\\d.]+)?\\;confidence:75\\;version:\\1",
 				"Set-Cookie": "PHPSESSID",
-				"X-Powered-By": "php/?([\\d.]+)?\\;confidence:40\\;version:\\1"
+				"X-Powered-By": "^(?:php|PHP)/?([\\d.]+)?\\;confidence:75\\;version:\\1"
 			},
 			"icon": "PHP.png",
 			"url": "\\.php(?:$|\\?)",


### PR DESCRIPTION
- Wappalyzer regexps are case-sensitive (or I misread the code, and this
  should be [documented](https://github.com/AliasIO/Wappalyzer/wiki/Specification)),
  This is why we should match both on `php` and `PHP`.
- Raise the confidence to `75%`, it was originally at `40%`. I'm in
  favour of raising it to 100%, but this shall go in another PR.

This is related to #1395