### PR TITLE
Fixed false EdgeCast CDN discovery

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2234,7 +2234,7 @@
 				31
 			],
 			"headers": {
-				"Server": "^EC(?:S|Acc)"
+				"Server": "^ECD\\s\\(\\S+\\)"
 			},
 			"icon": "EdgeCast.png",
 			"url": "https?://(?:[^/]+\\.)?edgecastcdn\\.net/",


### PR DESCRIPTION
Fixed: false discovery of EdgeCast CDN on Node's servers using github.com/jfhbrook/node-ecstatic middleware