### PR TITLE
Add additional implies for Craft CMS

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1639,10 +1639,7 @@
 				"X-Powered-By": "Craft CMS"
 			},
 			"icon": "Craft CMS.png",
-			"implies": [
-				"PHP",
-				"Yii"
-			],
+			"implies": "Yii",
 			"website": "http://buildwithcraft.com"
 		},
 		"Crazy Egg": {

--- a/src/apps.json
+++ b/src/apps.json
@@ -1639,7 +1639,10 @@
 				"X-Powered-By": "Craft CMS"
 			},
 			"icon": "Craft CMS.png",
-			"implies": "PHP",
+			"implies": [
+				"PHP",
+				"Yii"
+			],
 			"website": "http://buildwithcraft.com"
 		},
 		"Crazy Egg": {


### PR DESCRIPTION
I am not quite sure how `implies` works as far as inheritance.  CraftCMS is built off of the Yii framework.  The Yii framework is built off off PHP.