### PR TITLE
Remove the Elm language detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2265,15 +2265,6 @@
 			},
 			"website": "http://eleanor-cms.ru"
 		},
-		"Elm": {
-			"cats": [
-				27,
-				12
-			],
-			"env": "^Elm$",
-			"icon": "Elm.png",
-			"website": "http://elm-lang.org"
-		},
 		"Eloqua": {
 			"cats": [
 				32


### PR DESCRIPTION
Elm detection was based on the `Elm` pattern in `env`, leading to false
positives, as described [in the documentation](https://github.com/AliasIO/Wappalyzer/wiki/Specification#too-generic-patterns).