### PR TITLE
use absolute path to driver.js

### DIFF
--- a/src/drivers/phantomjs/index.js
+++ b/src/drivers/phantomjs/index.js
@@ -6,7 +6,7 @@ const
 	phantomjs = require('phantomjs-prebuilt');
 
 exports.run = function(args, callback) {
-	args.unshift.apply(args, ['driver.js', '--web-security=false', '--load-images=false', '--ignore-ssl-errors=yes', '--ssl-protocol=any']);
+	args.unshift.apply(args, [path.join(__dirname, 'driver.js'), '--web-security=false', '--load-images=false', '--ignore-ssl-errors=yes', '--ssl-protocol=any']);
 
 	var driver = phantomjs.exec.apply(this, args);
 


### PR DESCRIPTION
When I install via NPM and run this as a library as described in the readme, I get an error saying that driver.js cannot be found.  This patch fixes the error by calculating an absolute path and passing that to phantomjs.