### PR TITLE
Chrome driver always sends response to foreground page

### DIFF
--- a/src/drivers/webextension/js/driver.js
+++ b/src/drivers/webextension/js/driver.js
@@ -135,7 +135,8 @@
 		onMessage: function(message, sender, sendResponse) {
 			var
 				hostname,
-				a = document.createElement('a');
+				a = document.createElement('a'),
+				response = undefined;
 
 			if ( typeof message.id != 'undefined' ) {
 				w.log('message: ' + message.id);
@@ -164,15 +165,18 @@
 
 						break;
 					case 'get_apps':
-						sendResponse({
+						response = {
 							tabCache:   tabCache[message.tab.id],
 							apps:       w.apps,
 							categories: w.categories
-							});
+						};
 
 						break;
 				}
+
+				sendResponse( response );
 			}
+
 		},
 
 		goToURL: function(args) {


### PR DESCRIPTION
Chrome driver always sends response to foreground page to avoid foreground exception.

See #1487

This fixes #1487 and fixes #1489