### PR TITLE
Refactor Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,11 +8,19 @@ ENV WAPPALYZER_ROOT /home/wappalyzer/synced
 ENV WAPPALYZER_NODE_PATH /home/wappalyzer/node
 
 # Install packages
+RUN sed -i 's/^deb-src\ /\#deb-src\ /g' /etc/apt/sources.list
 RUN sed -i 's/archive\.ubuntu\.com/au.archive.ubuntu.com/g' /etc/apt/sources.list
-RUN apt-get update && apt-get install -y sudo curl
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get install -y nodejs bzip2 zip libfreetype6 libfontconfig rsync
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN sed -i 's/security\.ubuntu\.com/au.archive.ubuntu.com/g' /etc/apt/sources.list
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get install -y \
+        nodejs         \
+        bzip2          \
+        zip            \
+        libfreetype6   \
+        libfontconfig  \
+        rsync       && \
+    apt-get clean   && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
 # Add user


### PR DESCRIPTION
This change will make the docker image lighter(smaller) and also make the build process faster!
 - curl is builtin in phusion/baseimage, so there is no need to install it before nodesource
 - nodesource script will do apt-get update, so there is no need to do it manually
 - change security.ubuntu.com to use mirror site since it's very slow
 - separate apt package dependencies into different line so they can be easily traced by git
 - apt-get update cache clean up show be in the same layer of Docker image, or it'll not really work