### PR TITLE
Move Travis CI to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "node"
 sudo: false
+dist: trusty
 before_install:
  - export WAPPALYZER_ROOT=$TRAVIS_BUILD_DIR
  - export WAPPALYZER_NODE_PATH=$TRAVIS_BUILD_DIR
@@ -13,9 +14,3 @@ cache:
     - node_modules
 env:
   - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8


### PR DESCRIPTION
As GCC v4.8 is already installed, there is no need to use ubuntu-toolchain-r-test ppa for it, then we can speed up every CI round!