### PR TITLE
Updated OWL Carousel's site

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5505,7 +5505,7 @@
 			"icon": "OWL Carousel.png",
 			"implies": "jQuery",
 			"script": "owl.carousel.*\\.js",
-			"website": "http://owlgraphic.com/owlcarousel"
+			"website": "https://owlcarousel2.github.io/OwlCarousel2/"
 		},
 		"OXID eShop": {
 			"cats": [


### PR DESCRIPTION
OWL Carousel's site is now https://owlcarousel2.github.io/OwlCarousel2/
was http://owlgraphic.com/owlcarousel (reff: https://github.com/OwlCarousel2/OwlCarousel2/issues/1706 )