### PR TITLE
Fix Meteor implies

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -4912,8 +4912,7 @@
 			"icon": "Meteor.png",
 			"implies": [
 				"MongoDB",
-				"Node.js",
-				"jQuery"
+				"Node.js"
 			],
 			"website": "http://meteor.com"
 		},


### PR DESCRIPTION
Meteor does not imply jQuery if you use `static-html` package instead of `blaze-html-templates` package in case you are using `React` for [example](https://guide.meteor.com/react.html#using-with-meteor).
