### PR TITLE
add wordpress.com to apps.json

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8992,6 +8992,15 @@
 			"script": "/wp-includes/",
 			"website": "http://wordpress.org"
 		},
+		"WordPress.com": {
+			"cats": [
+				"1",
+				"11"
+			],
+			"html": "<meta name=\"generator\" content=\"WordPress.com\">",
+			"implies": "WordPress",
+			"website": "http://wordpress.com"
+		},
 		"WordPress Super Cache": {
 			"cats": [
 				"23"


### PR DESCRIPTION
WordPress.com is very different that Wordpress.org open source sites.