### PR TITLE
Update apps.json

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -254,12 +254,14 @@
 		"Adnegah": {
 			"cats": [
 				"36"
-			],
-			"env": "^ados(?:Results)?$",
+			], 
 			"html": "<iframe [^>]*src=\"[^\"]+adnegah\\.net",
 			"icon": "adnegah.png",
 			"script": "[^a-z]adnegah.*\\.js",
-			"website": "http://Adnegah.net"
+			"website": "http://Adnegah.net",
+			"headers": {
+				"X-Advertising-By": "adnegah.net"
+			},
 		},
 		"Adobe ColdFusion": {
 			"cats": [


### PR DESCRIPTION
i wanna add header http for remove non-related website from https://wappalyzer.com/applications/adnegah.
# 	Hostname
1 	stackoverflow.com
2 	askubuntu.com
3 	api.jquery.com
4 	magento.stackexchange.com
5 	wordpress.stackexchange.com
6 	serverfault.com
7 	superuser.com
8 	unix.stackexchange.com
9 	drupal.stackexchange.com
10 	jqueryui.com

these site do not use adnegah service but show adnegah icon in wapplayer!