### PR TITLE
update adnegah

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -254,12 +254,14 @@
 		"Adnegah": {
 			"cats": [
 				"36"
-			],
-			"env": "^ados(?:Results)?$",
+			],  
+			"headers": {
+				"X-Advertising-By": "adnegah.net"
+			},
 			"html": "<iframe [^>]*src=\"[^\"]+adnegah\\.net",
 			"icon": "adnegah.png",
-			"script": "[^a-z]adnegah.*\\.js",
-			"website": "http://Adnegah.net"
+			"script": "[^a-z]adnegah.*\\.js$", 
+			"website": "https://Adnegah.net"
 		},
 		"Adobe ColdFusion": {
 			"cats": [


### PR DESCRIPTION
i wanna remove non-related website from https://wappalyzer.com/applications/adnegah.
 
1 stackoverflow.com
2 askubuntu.com
3 api.jquery.com
4 magento.stackexchange.com
5 wordpress.stackexchange.com
6 serverfault.com
7 superuser.com
8 unix.stackexchange.com
9 drupal.stackexchange.com
10 jqueryui.com

these site do not use adnegah service but show adnegah icon in wapplayer!