### PR TITLE
fixed missing quotes on Category for uCoz

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8350,7 +8350,7 @@
 		},
 		"uCoz": {
 			"cats": [
-				1
+				"1"
 			],
 			"headers": {
 				"Set-Cookie": "uCoz="


### PR DESCRIPTION
was discovered because one of our build tests started failing