### PR TITLE
Add Zeit's now & next.js.

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5585,6 +5585,24 @@
 			"icon": "New Relic.png",
 			"website": "http://newrelic.com"
 		},
+		"Next.js": {
+			"cats": [
+				"18",
+				"22"
+			],
+			"headers": {
+				"x-powered-by": "^Next.js ?([0-9.]+)?\\;version:\\1"
+			},
+			"html": "<[^>]+__next",
+      "env": "^__NEXT_DATA__$",
+      "icon": "zeit.svg",
+			"implies": [
+				"React",
+				"webpack",
+				"Node.js"
+			],
+			"website": "https://zeit.co/next"
+		},
 		"Nginx": {
 			"cats": [
 				"22"
@@ -5613,6 +5631,16 @@
 			"implies": "Node.js",
 			"script": "^/nodebb\\.min\\.js\\?",
 			"website": "https://nodebb.org"
+		},
+		"Now": {
+			"cats": [
+				"22"
+			],
+			"headers": {
+				"server": "now"
+			},
+			"icon": "zeit.svg",
+			"website": "https://zeit.co/now"
 		},
 		"OWL Carousel": {
 			"cats": [

--- a/src/icons/zeit.svg
+++ b/src/icons/zeit.svg
@@ -1,0 +1,1 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><title>Zeit</title><desc>Created with Sketch.</desc><defs><linearGradient x1="100.686%" y1="181.283%" x2="41.808%" y2="100%" id="a"><stop stop-color="#fff" offset="0%"/><stop offset="100%"/></linearGradient></defs><path d="M15.766 3l14.766 26.134h-29.531z" fill-rule="nonzero" fill="url(#a)"/></svg>


### PR DESCRIPTION
Implements the detection of [now](https://zeit.co/now) and [Next.js](https://zeit.co/next).