### PR TITLE
Remove too broad rule for Next.js

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5601,7 +5601,6 @@
 			"headers": {
 				"x-powered-by": "^Next.js ?([0-9.]+)?\\;version:\\1"
 			},
-			"html": "<[^>]+__next",
       "env": "^__NEXT_DATA__$",
       "icon": "zeit.svg",
 			"implies": [


### PR DESCRIPTION
As discussed in #1680 and #1706, html rule is too broad. The other two rules should cover the detection sufficiently.