### PR TITLE
Improve React detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -6787,7 +6787,7 @@
 			"cats": [
 				"12"
 			],
-			"env": "^React$",
+			"env": "^__REACT_DEVTOOLS_GLOBAL_HOOK__$",
 			"html": "<[^>]+data-react",
 			"icon": "React.png",
 			"script": [


### PR DESCRIPTION
React 16 has removed ```data-reactroot``` attribute and wappalyzer can not detect React 16 correctly.
But React has a global variable ```__REACT_DEVTOOLS_GLOBAL_HOOK__```.