### PR TITLE
Fix RaphaelJS website

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -6864,7 +6864,7 @@
 			"env": "^Raphael$",
 			"icon": "Raphael.png",
 			"script": "raphael.*\\.js",
-			"website": "http://raphaeljs.com"
+			"website": "http://dmitrybaranovskiy.github.io/raphael/"
 		},
 		"Rapid Logic": {
 			"cats": [


### PR DESCRIPTION
The RaphaelJS website http://raphaeljs.com/ is dead, now the address is http://dmitrybaranovskiy.github.io/raphael/