### PR TITLE
Detect newer versions of Sails.js

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -7359,7 +7359,7 @@
 			],
 			"headers": {
 				"Set-Cookie": "^sails\\.sid$",
-				"X-Powered-By": "^Sails$"
+				"X-Powered-By": "^Sails(?:$|[^a-z0-9])"
 			},
 			"icon": "Sails.js.svg",
 			"implies": "Express",


### PR DESCRIPTION
As noted in https://github.com/AliasIO/Wappalyzer/issues/1432#issuecomment-287586126

Newer Sails.js versions send the header

    x-powered-by: Sails <sailsjs.org>
instead of

    x-powered-by: Sails

I tried to write a pattern that is hopefully more future-proof without generating too many false positives.