### PR TITLE
Improve a bit ikiwiki detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -10223,7 +10223,7 @@
 				"8"
 			],
 			"html": [
-				"<link rel=\"alternate\" type=\"application/x-wiki\" title=\"Edit this page\" href=\"[^\\"]*/ikiwiki\\.cgi",
+				"<link rel=\"alternate\" type=\"application/x-wiki\" title=\"Edit this page\" href=\"[^\"]*/ikiwiki\\.cgi",
 				"<a href=\"/(?:cgi-bin/)?ikiwiki\\.cgi\\?do="
 			],
 			"icon": "ikiwiki.png",

--- a/src/apps.json
+++ b/src/apps.json
@@ -10223,8 +10223,8 @@
 				"8"
 			],
 			"html": [
-				"<link rel=\"alternate\" type=\"application/x-wiki\" title=\"Edit this page\" href=\"/ikiwiki\\.cgi",
-				"<a href=\"/ikiwiki\\.cgi\\?do="
+				"<link rel=\"alternate\" type=\"application/x-wiki\" title=\"Edit this page\" href=\"[^\\"]*/ikiwiki\\.cgi",
+				"<a href=\"/(?:cgi-bin/)?ikiwiki\\.cgi\\?do="
 			],
 			"icon": "ikiwiki.png",
 			"website": "http://ikiwiki.info"


### PR DESCRIPTION
This can be verified [here](http://blog.spang.cc/posts/hledger_rocks_my_world/). Apparently
people may put ikiwiki in the good ol' `/cgi-bin` folder instead of the root of their website. This makes sense, since ikiwiki is a big pile of Perl.