### PR TITLE
Low confidence for 2-character environment variables

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2322,7 +2322,10 @@
 				"12"
 			],
 			"icon": "ef.js.svg",
-			"env": "^ef|efCore$",
+			"env": [
+				"^ef$\\;confidence:20",
+				"^efCore$"
+			],
 			"script": "/ef(?:-core)?(?:\\.min|\\.dev)?\\.js",
 			"website": "http://ef.js.org"
 		},
@@ -4401,7 +4404,7 @@
 			"cats": [
 				"12"
 			],
-			"env": "^ko$",
+			"env": "^ko$\\;confidence:20",
 			"icon": "Knockout.js.png",
 			"website": "http://knockoutjs.com"
 		},
@@ -7959,7 +7962,7 @@
 			"cats": [
 				"12"
 			],
-			"env": "^io$",
+			"env": "^io$\\;confidence:20",
 			"icon": "Socket.io.png",
 			"implies": "Node.js",
 			"script": "socket.io.*\\.js",


### PR DESCRIPTION
These can be automatically generated by the Google Closure Compiler (which will, if configured, replace global variables with auto-generated ones such as `aa`, `ab`, `ac` et cetera.) Hence, they are a less reliable
indication that a library which would also set said variable is present.