### PR TITLE
Fixed userAgent param doing nothing for npm driver

### DIFF
--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -4,9 +4,7 @@ const driver = options => {
   const Wappalyzer = require('./wappalyzer');
   const request = require('request');
   const fs = require('fs');
-  const Browser = require('zombie', {
-    userAgent: options.userAgent
-  });
+  const Browser = require('zombie');
 
   const json = JSON.parse(fs.readFileSync(__dirname + '/apps.json'));
 
@@ -57,7 +55,7 @@ const driver = options => {
           resolve(apps);
         };
 
-        const browser = new Browser();
+        const browser = new Browser({userAgent: options.userAgent});
 
         browser.visit(url, error => {
           if ( !browser.resources['0'] || !browser.resources['0'].response ) {


### PR DESCRIPTION
If you run npm driver with --userAgent specified, it's not used and on request to the server used the default value of "Mozilla/5.0 Chrome/10.0.613.0 Safari/534.15 Zombie.js/5.0.7"

Moved userAgent init to the line of Browser() instance creation instead of require