### PR TITLE
Detect when cloudflare is used as a CDN

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1558,6 +1558,7 @@
 				"Server": "cloudflare"
 			},
 			"icon": "CloudFlare.svg",
+			"script": "cloudflare.com/",
 			"website": "http://www.cloudflare.com"
 		},
 		"Cloudera": {


### PR DESCRIPTION
If this PR is merged, wappalyzer will show the cloudflare icon when some
resources used by the website are pulled from cloudflare. Currently,
it's shown only when the website is *behind* cloudflare.

Do we want to change this behaviour?