### PR TITLE
Add a way to get gravityform's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3368,7 +3368,7 @@
 				"<ul [^>]*class=(?:\"|')[^>]*gform_fields",
 				"<link [^>]*href=(?:\"|')[^>]*wp-content/plugins/gravityforms/css/"
 			],
-			"script": "/wp-content/plugins/gravityforms/js/[^/]+\\.js\\?ver=([\d.]+)$\\;version:\\1",
+			"script": "/wp-content/plugins/gravityforms/js/[^/]+\\.js\\?ver=([\\d.]+)$\\;version:\\1",
 			"icon": "gravityforms.svg",
 			"implies": "WordPress",
 			"website": "http://gravityforms.com"

--- a/src/apps.json
+++ b/src/apps.json
@@ -3368,6 +3368,7 @@
 				"<ul [^>]*class=(?:\"|')[^>]*gform_fields",
 				"<link [^>]*href=(?:\"|')[^>]*wp-content/plugins/gravityforms/css/"
 			],
+			"script": "/wp-content/plugins/gravityforms/js/[^/]+\\.js\\?ver=([\d.]+)$\\;version:\\1",
 			"icon": "gravityforms.svg",
 			"implies": "WordPress",
 			"website": "http://gravityforms.com"


### PR DESCRIPTION
This can be tested [here](https://about.mattermost.com/blog/)