### PR TITLE
Add an other way to get jquery's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -10373,7 +10373,7 @@
 			"script": [
 				"jquery(?:\\-|\\.)([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
 				"/([\\d.]+)/jquery(?:\\.min)?\\.js\\;version:\\1",
-				"jquery.*\\.js"
+				"jquery.*\\.js(?:\\?ver=([\d.]+))?\\;version:\\1"
 			],
 			"website": "http://jquery.com"
 		},

--- a/src/apps.json
+++ b/src/apps.json
@@ -10373,7 +10373,7 @@
 			"script": [
 				"jquery(?:\\-|\\.)([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
 				"/([\\d.]+)/jquery(?:\\.min)?\\.js\\;version:\\1",
-				"jquery.*\\.js(?:\\?ver=([\d.]+))?\\;version:\\1"
+				"jquery.*\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1"
 			],
 			"website": "http://jquery.com"
 		},


### PR DESCRIPTION
This syntax is used by wordpress, and can be tested [here](https://about.mattermost.com/blog/)