### PR TITLE
Add a way to get underscore's version, on Wordpress

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8984,7 +8984,7 @@
 				"12"
 			],
 			"icon": "Underscore.js.png",
-			"script": "underscore.*\\.js",
+			"script": "underscore.*\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1",
 			"website": "http://underscorejs.org"
 		},
 		"Usabilla": {


### PR DESCRIPTION
This can be tested [here](https://www.aviwell.fr)