### PR TITLE
Remove some useless "confidence" stuff

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3408,7 +3408,7 @@
 				"X-Powered-By": "HHVM/?([\\d.]+)?\\;version:\\1"
 			},
 			"icon": "HHVM.png",
-			"implies": "PHP\\;confidence:50",
+			"implies": "PHP",
 			"website": "http://hhvm.com"
 		},
 		"HP": {
@@ -5098,9 +5098,7 @@
 			"icon": "mattermost.png",
 			"implies": [
 				"Go",
-				"React",
-				"PostgreSQL\\;confidence:50",
-				"MySQL\\;confidence:50"
+				"React"
 			],
 			"website": "http://about.mattermost.com"
 		},
@@ -5242,7 +5240,7 @@
 			"headers": {
 				"Set-Cookie": "ASPSESSION|ASP\\.NET_SessionId",
 				"X-AspNet-Version": "(.+)\\;version:\\1",
-				"X-Powered-By": "ASP\\.NET\\;confidence:50"
+				"X-Powered-By": "ASP\\.NET"
 			},
 			"html": "<input[^>]+name=\"__VIEWSTATE",
 			"icon": "Microsoft ASP.NET.png",
@@ -6886,7 +6884,7 @@
 				"27"
 			],
 			"headers": {
-				"Server": "(?:^|\\s)Python(?:/([\\d.]+))?\\;confidence:50\\;version:\\1"
+				"Server": "(?:^|\\s)Python(?:/([\\d.]+))?\\;version:\\1"
 			},
 			"icon": "Python.png",
 			"website": "http://python.org"
@@ -7218,7 +7216,7 @@
 			"icon": "RiteCMS.png",
 			"implies": [
 				"PHP",
-				"SQLite\\;confidence:50"
+				"SQLite\\;confidence:80"
 			],
 			"meta": {
 				"generator": "^RiteCMS(?: (.+))?\\;version:\\1"
@@ -8842,7 +8840,7 @@
 			],
 			"env": "^typeahead$",
 			"icon": "Twitter typeahead.js.png",
-			"implies": "jQuery\\;confidence:50",
+			"implies": "jQuery",
 			"script": "(?:typeahead|bloodhound)\\.(?:jquery|bundle)?(?:\\.min)?\\.js",
 			"website": "http://twitter.github.io/typeahead.js"
 		},

--- a/src/apps.json
+++ b/src/apps.json
@@ -5240,7 +5240,7 @@
 			"headers": {
 				"Set-Cookie": "ASPSESSION|ASP\\.NET_SessionId",
 				"X-AspNet-Version": "(.+)\\;version:\\1",
-				"X-Powered-By": "ASP\\.NET"
+				"X-Powered-By": "ASP\\.NET\\;confidence:50"
 			},
 			"html": "<input[^>]+name=\"__VIEWSTATE",
 			"icon": "Microsoft ASP.NET.png",

--- a/src/apps.json
+++ b/src/apps.json
@@ -3408,7 +3408,7 @@
 				"X-Powered-By": "HHVM/?([\\d.]+)?\\;version:\\1"
 			},
 			"icon": "HHVM.png",
-			"implies": "PHP",
+			"implies": "PHP\\;confidence:75",
 			"website": "http://hhvm.com"
 		},
 		"HP": {


### PR DESCRIPTION
- HHVM implies PHP
- Mattermost can run on Postgre or Mysql, there is no point in showing them both at 50%, we don't do this for anything else
- If something is powered by ASP.NET, it's running ASP.NET
- If there is "Python" in a "Server" header, it's powered by Python
- RiteCMS is running on SQLite by default, it's the whole point of running this CMS instead of something more heavy
- JQuery is a mandatory dependency of typeahead