### PR TITLE
Add a way to get highlight.js version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3632,7 +3632,7 @@
 				"19"
 			],
 			"icon": "Highlight.js.png",
-			"script": "/highlight\\.js/[\\d.]+?/highlight\\.min\\.js",
+			"script": "/highlight\\.js/([\\d.]+)/highlight\\.min\\.js\\;version:\\1",
 			"website": "https://highlightjs.org/"
 		},
 		"Highstock": {


### PR DESCRIPTION
The original regexp was already suboptimal, but apparently, this is how everyone uses this javascript library. This can be tested [here](https://forum.openmw.org/)