### PR TITLE
Improve mediawiki version detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5197,9 +5197,10 @@
 			],
 			"html": "(?:<a[^>]+>Powered by MediaWiki</a>|<[^>]+id=\"t-specialpages)",
 			"icon": "MediaWiki.png",
+			"env": "^mediaWiki$",
 			"implies": "PHP",
 			"meta": {
-				"generator": "^MediaWiki ?([\\d.]+)$\\;version:\\1"
+				"generator": "^MediaWiki ?([\\d.]+)\\;version:\\1"
 			},
 			"website": "http://www.mediawiki.org"
 		},


### PR DESCRIPTION
The versions of mediawiki can be a bit strange,
especially on [wikipedia](https://en.wikipedia.org/wiki/United_Arab_Emirates),
since apparently the WMF has special ones. I've also seen `-beta`
sometimes (altough I don't have a website handy to prove it, sorry :/ )