### PR TITLE
Add a way to get Font-awesome's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2799,7 +2799,7 @@
 				"17"
 			],
 			"html": [
-				"<link[^>]* href=[^>]+font-awesome(?:\\.min)?\\.css",
+				"<link[^>]* href=[^>]+(:?/([\\d.]+)/css)?/font-awesome(?:\\.min)?\\.css\\;version:\\1",
 				"<script[^>]* src=[^>]+fontawesome(?:\\.js)?"
 			],
 			"icon": "Font Awesome.png",

--- a/src/apps.json
+++ b/src/apps.json
@@ -2799,7 +2799,7 @@
 				"17"
 			],
 			"html": [
-				"<link[^>]* href=[^>]+(:?/([\\d.]+)/css)?/font-awesome(?:\\.min)?\\.css\\;version:\\1",
+				"<link[^>]* href=[^>]+(?:/([\\d.]+)/css)?/font-awesome(?:\\.min)?\\.css\\;version:\\1",
 				"<script[^>]* src=[^>]+fontawesome(?:\\.js)?"
 			],
 			"icon": "Font Awesome.png",


### PR DESCRIPTION
This can be tested [here](https://apnews.com/7f9e63cb14a54dfa9148b6430d89e873).
This url form is used on a lot of CDN.