### PR TITLE
Update SweetAlert2 to detect .all.js

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8436,7 +8436,7 @@
 			"excludes": "SweetAlert",
 			"html": "<link[^>]+?href=\"[^\"]+sweetalert2(?:\\.min)?\\.css",
 			"icon": "SweetAlert2.png",
-			"script": "sweetalert2(?:\\.min)?\\.js",
+			"script": "sweetalert2(?:\\.all)?(?:\\.min)?\\.js",
 			"website": "https://limonte.github.io/sweetalert2"
 		},
 		"Swiftlet": {


### PR DESCRIPTION
Fix detecting of `sweetalert2.all.js` and `sweetalert2.all.min.js` which were introduced recently.