### PR TITLE
Add a way to get mootool's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5585,8 +5585,11 @@
 			],
 			"env": "^MooTools$",
 			"icon": "MooTools.png",
-			"script": "mootools.*\\.js",
-			"website": "http://mootools.net"
+			"script": [
+				"/mootools-core-([\\d.]+)\\.js\\;version:\\1",
+				"/mootools.*\\.js"
+			],
+			"website": "https://mootools.net"
 		},
 		"Moodle": {
 			"cats": [


### PR DESCRIPTION
- The website is now in https
- Tighten a bit the original regexp by prefixing it with a `/`
- Add a regexp to get the version, this can be tested [here](https://turtlapp.com/docs/)