### PR TITLE
Add an other way to fingerprint google tag manager

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3318,7 +3318,10 @@
 				"^googletag$",
 				"^google_tag_manager$"
 			],
-			"html": "googletagmanager\\.com/ns\\.html[^>]+></iframe>",
+			"html": [
+				"googletagmanager\\.com/ns\\.html[^>]+></iframe>",
+				"<!-- (?:End )?Google Tag Manager -->"
+			],
 			"icon": "Google Tag Manager.png",
 			"website": "http://www.google.com/tagmanager"
 		},


### PR DESCRIPTION
This can be tested [here](https://www.concardis.com/e-commerce/concardis-payengine), it's a common pattern.