### PR TITLE
Add an other way to get bootstrap's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8904,6 +8904,7 @@
 			],
 			"html": [
 				"<style>/\\*!\\* Bootstrap v(\\d\\.\\d\\.\\d)\\;version:\\1",
+				"<link[^>]+?href=[^\"]/css/([\\d.]+)/bootstrap\\.(?:min\\.)?css\\;version:\\1",
 				"<link[^>]+?href=\"[^\"]*bootstrap(?:\\.min)?\\.css",
 				"<div[^>]+class=\"[^\"]*glyphicon glyphicon-"
 			],


### PR DESCRIPTION
This pattern is popular among CDN like Clownflare, and can be tested [here](https://www.elttam.com.au/blog/goahead/)