### PR TITLE
Fixed OpenUI5 Detection (fix #1906)

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -6210,7 +6210,7 @@
 				"12"
 			],
 			"icon": "OpenUI5.png",
-			"env": "sap\\.ui$",
+			"script": "sap-ui-core\\.js",
 			"website": "http://openui5.org/"
 		},
 		"OpenX": {


### PR DESCRIPTION
Fixes the OpenUI5 detection by using the script name instead of checking the javascript variable.

Thanks to @gadcam.
I'm not using the version detection of your regexp because there is not always the version cdn in use. It can also be used a generelly "latest" cdn like this:
https://openui5.hana.ondemand.com/resources/sap-ui-core.js