### PR TITLE
Improve the regexp to get jquery's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -10470,7 +10470,7 @@
 			"script": [
 				"jquery(?:\\-|\\.)([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
 				"/([\\d.]+)/jquery(?:\\.min)?\\.js\\;version:\\1",
-				"jquery.*\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1"
+				"jquery.*\\.js(?:\\?ver(?:sion)?=([\\d.]+))?\\;version:\\1"
 			],
 			"website": "http://jquery.com"
 		},


### PR DESCRIPTION
Joomla and its friends are using it. And even if they didn't, it's still a common pattern.

This can be tested [here](boa.realm667.com).