### PR TITLE
Fix #1944 not working XenForo detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9822,7 +9822,7 @@
 			"cats": [
 				"2"
 			],
-			"html": "(?:jQuery\\.extend\\(true, XenForo|Forum software by XenForo&trade;|<!--XF:branding|<html[^>]+id=\"XenForo\")",
+			"html": "(?:jQuery\\.extend\\(true, XenForo|Forum software by XenForo™|<!--XF:branding|<html[^>]+id=\"XenForo\")",
 			"icon": "XenForo.png",
 			"website": "http://xenforo.com"
 		},


### PR DESCRIPTION
Fix of the XenForo forum software detection. 
Example URL: https://forum.sinusbot.com