### PR TITLE
Add an other way to get mathjax' version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5466,7 +5466,7 @@
         "MathJax.version": "(.*)\\;version:\\1"
       },
       "icon": "MathJax.png",
-      "script": "mathjax\\.js",
+      "script": "([\\d.]+)?/mathjax\\.js\\;version:\\1",
       "website": "https://www.mathjax.org"
     },
     "Mattermost": {


### PR DESCRIPTION
This can be tested [here](https://clang.llvm.org/docs/ControlFlowIntegrity.html)