### PR TITLE
Add yet another way to detect bootstrap's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9586,7 +9586,7 @@
       "script": [
         "twitter\\.github\\.com/bootstrap",
         "bootstrap(?:\\-|\\.)([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
-        "(?:/([\\d.]+)/)bootstrap(?:\\.min)?\\.js\\;version:\\1"
+        "(?:/([\\d.]+))?(?:/js)?/bootstrap(?:\\.min)?\\.js\\;version:\\1"
       ],
       "website": "https://getbootstrap.com"
     },


### PR DESCRIPTION
This one is popular amongst CDN, and can be tested [here](https://www.ripstech.com/php-security-calendar-2017/)