### PR TITLE
Enable the use of W in Firefox for Android

### DIFF
--- a/src/drivers/webextension/js/driver.js
+++ b/src/drivers/webextension/js/driver.js
@@ -248,10 +248,14 @@ wappalyzer.driver.displayApps = (detected, meta, context) => {
                   icon = 'converted/' + icon.replace(/\.svg$/, '.png');
                 }
 
-                browser.pageAction.setIcon({
-                  tabId: tab.id,
-                  path: '../images/icons/' + icon
-                });
+                try {
+                	browser.pageAction.setIcon({
+                    tabId: tab.id,
+                    path: '../images/icons/' + icon
+                  });
+                } catch(e) {
+                  // Firefox for Android does not support setIcon see https://bugzilla.mozilla.org/show_bug.cgi?id=1331746
+                }
 
                 found = true;
               }


### PR DESCRIPTION
This pull request enables to use Wappalyzer in Firefox for Android, before the extension was not showing up because of this bug and I could not spot any error in the console.

However : 
  - it is not possible to change the icon in the URL bar (cf https://bugzilla.mozilla.org/show_bug.cgi?id=1331746)
  - the popup needs a bit of work to be clean in Firefox for Android