### PR TITLE
Change database manager priority

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -12069,7 +12069,7 @@
     },
     "3": {
       "name": "Database Managers",
-      "priority": "9"
+      "priority": "4"
     },
     "4": {
       "name": "Documentation Tools",


### PR DESCRIPTION
I think that "database manager" must have higher priority than others categories like "misc", "operating system" ...
