### PR TITLE
Yoast SEO implies WordPress

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -10758,6 +10758,7 @@
         "<!-- This site is optimized with the Yoast SEO plugin v([\\d.]+) -\\;version:\\1"
       ],
       "icon": "Yoast SEO.png",
+      "implies": "WordPress",
       "website": "http://yoast.com"
     },
     "YouTrack": {


### PR DESCRIPTION
The detection of the The Yoast SEO plugin implies the underlying site is powered by WordPress.

https://yoast.com/wordpress/plugins/seo/