### PR TITLE
Fix: jQuery Migrate detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11312,6 +11312,9 @@
       "cats": [
         "12"
       ],
+      "js": {
+        "jQuery.migrateVersion": "([\\d.]+)\\;version:\\1"
+      },
       "icon": "jQuery.svg",
       "implies": "jQuery",
       "script": "jquery.migrate(?:-([\\d.]+rc\\d))?.*\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",


### PR DESCRIPTION
Adding `jQuery.migrateVersion` for version detection via JavaScript: 
https://github.com/jquery/jquery-migrate/blob/180a4531d6efb0c28cbdcef32f0a9033506eac10/README.md#migrate-plugin-api

Example sites on which you can test:
- https://www.tsv-rannungen.de/
  