### PR TITLE
Update SweetAlert2 to detect .all.js

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9170,7 +9170,7 @@
       "excludes": "SweetAlert",
       "html": "<link[^>]+?href=\"[^\"]+sweetalert2(?:\\.min)?\\.css",
       "icon": "SweetAlert2.png",
-      "script": "sweetalert2(?:\\.min)?\\.js",
+      "script": "sweetalert2(?:\\.all)?(?:\\.min)?\\.js",
       "website": "https://limonte.github.io/sweetalert2"
     },
     "Swiftlet": {


### PR DESCRIPTION
The same as https://github.com/AliasIO/Wappalyzer/pull/1922

I don't know why the previous change has been undone :confused: 