### PR TITLE
Update Craft CMS detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1984,7 +1984,7 @@
       ],
       "headers": {
         "Set-Cookie": "^CraftSessionId=",
-        "X-Powered-By": "^Craft CMS$"
+        "X-Powered-By": "\\bCraft CMS\\b"
       },
       "icon": "Craft CMS.svg",
       "implies": "Yii",


### PR DESCRIPTION
Craft’s `X-Powered-By` header could start including other details besides the product name, so all we should care about is that “Craft CMS” is in there somewhere.