### PR TITLE
Fix problem in version detection via js variables

### DIFF
--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -246,7 +246,7 @@ class Driver {
             return parent && parent.hasOwnProperty(property) ? parent[property] : null;
           }, browser.window);
 
-          value = typeof value === 'string' ? value : !!value;
+          value = typeof value === 'string' || typeof value === 'number' ? value : !!value;
 
           if ( value ) {
             js[appName][chain][index] = value;

--- a/src/drivers/webextension/js/inject.js
+++ b/src/drivers/webextension/js/inject.js
@@ -53,7 +53,7 @@
         }
       }
 
-      return typeof value === 'string' ? value : !!value;
+      return typeof value === 'string' || typeof value === 'number' ? value : !!value;
     } catch(e) {
       // Fail quietly
     }


### PR DESCRIPTION
Fix bug spotted in #2031 :
When the matched element is a number it just returns "True" and not the number.
