### PR TITLE
Remove `ng-version` detection from AngularJS

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -631,7 +631,7 @@
       "cats": [
         12
       ],
-      "html": "<[^>]+ ng-version=\"([\\d.]+)\">\\;version:\\1",
+      "html": "<[^>]+ ng-version=\"([\\d.]+)\"\\;version:\\1",
       "icon": "Angular.svg",
       "website": "https://angular.io"
     },
@@ -643,7 +643,6 @@
         "angular": "",
         "angular.version.full": "(.*)\\;version:\\1"
       },
-      "html": "<[^>]+ ng-version=\"([\\d.]+)\">\\;version:\\1",
       "icon": "AngularJS.svg",
       "script": [
         "angular(?:\\-|\\.)([\\d.]*\\d)[^/]*\\.js\\;version:\\1",


### PR DESCRIPTION
OK, this may look familiar, since I sent a PR like this myself. (#2042)  But before it got merged an hour ago, @AliasIO merge `master` into my branch so that the line I intended to remove reappears. (https://github.com/AliasIO/Wappalyzer/pull/2042/commits/f79a6dd315924719b41bbf167f149cbfffaf33e9)

This fixes merge messed up in #2042.

Please be careful before merging.

