### PR TITLE
Added Craft Commerce detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2054,6 +2054,17 @@
       "implies": "Yii",
       "website": "https://craftcms.com"
     },
+    "Craft Commerce": {
+      "cats": [
+        6
+      ],
+      "headers": {
+        "X-Powered-By": "\\bCraft Commerce\\b"
+      },
+      "icon": "Craft CMS.svg",
+      "implies": "Craft CMS",
+      "website": "https://craftcommerce.com"
+    },
     "Crazy Egg": {
       "cats": [
         10


### PR DESCRIPTION
[Craft Commerce](https://craftcommerce.com/) is an e-commerce platform for Craft CMS websites. Its next release will start identifying itself via the `X-Powered-By` header, so it can be detected by Wappalyzer.

It’s currently running on a bit over 500 sites. Here are a few of them:

- https://fieldnotesbrand.com/
- https://barefootcontessa.com/
- https://cheerfullygiven.com/
- https://begladtraining.com/
- https://transformcorp.com/
- https://unitedslings.com/
- https://yveslegare.com/
- https://coldpresscoffee.com/
- https://www.jacketconcept.com/
- https://cunliffeandwaters.com.au/
- https://cfj.com.au/
- https://brink.uk/
- https://www.thirskracecourse.net/
- https://www.typemates.com/
- https://vfmk.org/
- https://www.weightcare.nl/
- https://www.uk-tefl.com/
- https://woodiesatberlin.nl/
- https://www.wicycle.com/
- https://classlegal.com/
- https://www.weizmann.org.uk/
- https://parotecsolutions.co.uk/
- https://oakcliffcoffee.com/
- https://iwantmychurchtogrow.com/
- https://www.promtuxedo.com/
- https://www.modifast.nl/
- https://vgsstudiod.com/
- https://www.holzweiler.no/
- https://www.quax.eu/
- https://citb.org.au/
- https://www.fivetwo.com/
- https://childsown.com/
- https://www.alexander-mueller.at/
- https://nomaden.no/
- https://wagbat.com/
- http://aaltopaint.adhesion.co.nz/
- https://www.chronosnet.com/
- https://www.youngvoices.co.uk/
- https://www.fishkeeper.co.uk/
- https://www.gmyle.com/
- https://bcsamerica.com/
- http://airness.it/