### PR TITLE
Simplify mediawiki version detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5746,7 +5746,7 @@
       "icon": "MediaWiki.png",
       "implies": "PHP",
       "meta": {
-        "generator": "^MediaWiki ?([\\d.]+)$\\;version:\\1"
+        "generator": "^MediaWiki ?(.+)$\\;version:\\1"
       },
       "website": "http://www.mediawiki.org"
     },


### PR DESCRIPTION
Mediawiki versions can contain a lot of different letters, like [`1.31.0-wmf.17`](view-source:https://en.wikipedia.org/wiki/Token_bucket), so there is no need to check for numbers specifically.