### PR TITLE
Add a new way to get bootstrap's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9713,6 +9713,9 @@
         "<link[^>]+?href=\"[^\"]*bootstrap(?:\\.min)?\\.css",
         "<div[^>]+class=\"[^\"]*glyphicon glyphicon-"
       ],
+      "js": {
+        "bootstrap.Alert.VERSION": "(.*)\\;version:\\1"
+      },
       "icon": "Bootstrap.svg",
       "script": [
         "twitter\\.github\\.com/bootstrap",


### PR DESCRIPTION
This can be tested [here](http://storm-country.com/blog/evo-deco), based on [this method](https://github.com/twbs/bootstrap/issues/16264)