### PR TITLE
Add a way to get algolia's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -519,7 +519,8 @@
         29
       ],
       "js": {
-        "AlgoliaSearch": ""
+        "AlgoliaSearch": "",
+        "algoliasearch.version": "(.*)\\;version:\\1"
       },
       "icon": "Algolia Realtime Search.svg",
       "website": "http://www.algolia.com"


### PR DESCRIPTION
This can be tested [here](https://blog.heroku.com/ruby-2-4-features-hashes-integers-rounding#better-hashes).
Please note that `algoliasearch` and `AlgoliaSearch` are both present on
the webpage