### PR TITLE
Add a way to get socket.io's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8872,7 +8872,7 @@
         12
       ],
       "js": {
-        "io": "\\;confidence:20"
+        "io.version": "(.*)\\;version:\\1\\;confidence:20"
       },
       "icon": "Socket.io.png",
       "implies": "Node.js",


### PR DESCRIPTION
This can be tested [here](https://cloud.scaleway.com/#/)