### PR TITLE
Add a way to get XRegExp's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -10716,7 +10716,7 @@
         12
       ],
       "js": {
-        "XRegExp": ""
+        "XRegExp.version": "(.*)\\;version:\\1"
       },
       "icon": "XRegExp.png",
       "script": [


### PR DESCRIPTION
This can be tested [here]( http://guides.rubyonrails.org/security.html#regular-expressions )