### PR TITLE
Improve Concerte5 handling

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1896,10 +1896,10 @@
       "icon": "Concrete5.png",
       "implies": "PHP",
       "meta": {
-        "generator": "concrete5 - ([\\d.ab]+)\\;version:\\1"
+        "generator": "^concrete5 - ([\\d.]+)$\\;version:\\1"
       },
-      "script": "concrete/js/",
-      "website": "http://concrete5.org"
+      "script": "/concrete/js/",
+      "website": "https://concrete5.org"
     },
     "Connect": {
       "cats": [


### PR DESCRIPTION
- Better version detection (the `ab` thingy looks like a bug to me)
- Tighten the regexp for the generator
- Tighten the `script` thingy
- The website is using https

This can be tested [here]( http://www.nextprivacy.ch/fr/solutions/outils/ )