### PR TITLE
Using `reduce` to remove extra iterations

### DIFF
--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -134,10 +134,13 @@ class Driver {
       })
         .then(() => {
           const links = Array.from(browser.document.getElementsByTagName('a'))
-            .filter(link => link.protocol === 'http:' || link.protocol === 'https:')
-            .filter(link => link.hostname === this.origPageUrl.hostname)
-            .filter(link => extensions.test(link.pathname))
-            .map(link => { link.hash = ''; return url.parse(link.href) });
+            .reduce((acc, link) => {
+              if (link.protocol.match(/https?:/) || link.hostname === this.origPageUrl.hostname || extensions.test(link.pathname)) {
+                link.hash = '';
+                acc.push(url.parse(link.href));
+              }
+              return acc;
+            }, []);
 
           return resolve(links);
         });

--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -133,14 +133,17 @@ class Driver {
         js
       })
         .then(() => {
-          const links = Array.from(browser.document.getElementsByTagName('a'))
-            .reduce((acc, link) => {
+          const links = Array.prototype.reduce.call(
+            browser.document.getElementsByTagName('a'),
+            (acc, link) => {
               if (link.protocol.match(/https?:/) || link.hostname === this.origPageUrl.hostname || extensions.test(link.pathname)) {
                 link.hash = '';
                 acc.push(url.parse(link.href));
               }
               return acc;
-            }, []);
+            },
+            []
+          );
 
           return resolve(links);
         });


### PR DESCRIPTION
This code iterates a list of links 5 times -- 1 to `from`, 3 to `filter`, and then 1 to `map`. This can be simplified into one `reduce` which iterates the list once.