### PR TITLE
Add a way to get Stripe's version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9175,7 +9175,7 @@
         41
       ],
       "js": {
-        "Stripe": ""
+        "Stripe.version": "(.*)\\;version:\\1"
       },
       "html": "<input[^>]+data-stripe",
       "icon": "Stripe.png",


### PR DESCRIPTION
This can be tested [here](https://stripe.com/atlas/guides/business-of-saas)