### PR TITLE
Github pages are now only a CDN, and not a blog

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3425,7 +3425,6 @@
     },
     "GitHub Pages": {
       "cats": [
-        11,
         31
       ],
       "url": "^https?://[^/]+\\.github\\.io/",


### PR DESCRIPTION
The rationale for this commit is that when you're putting content on github
pages, the underlying blog engine is Jekyll, or anything else that you might
use to generate static html. Github pages are only the things that is serving
your pages, aka a content delivery network.