### PR TITLE
Improve jquery migrate and jquery mobile detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11445,7 +11445,7 @@
       },
       "icon": "jQuery.svg",
       "implies": "jQuery",
-      "script": "jquery.migrate(?:-([\\d.]+rc\\d))?.*\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",
+      "script": "jquery[\\.-]migrate(?:-([\\d.]))?(?:\\.min)?\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",
       "website": "https://github.com/jquery/jquery-migrate"
     },
     "jQuery Mobile": {
@@ -11454,7 +11454,7 @@
       ],
       "icon": "jQuery Mobile.svg",
       "implies": "jQuery",
-      "script": "jquery\\.mobile(?:-([\\d.]+rc\\d))?.*\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",
+      "script": "jquery[\\.-]mobile(?:-([\\d.]))?(?:\\.min)?\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",
       "website": "https://jquerymobile.com"
     },
     "jQuery Sparklines": {

--- a/src/apps.json
+++ b/src/apps.json
@@ -11445,7 +11445,7 @@
       },
       "icon": "jQuery.svg",
       "implies": "jQuery",
-      "script": "jquery[\\.-]migrate(?:-([\\d.]))?(?:\\.min)?\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",
+      "script": "jquery[.-]migrate(?:-([\\d.]))?(?:\\.min)?\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",
       "website": "https://github.com/jquery/jquery-migrate"
     },
     "jQuery Mobile": {
@@ -11454,7 +11454,7 @@
       ],
       "icon": "jQuery Mobile.svg",
       "implies": "jQuery",
-      "script": "jquery[\\.-]mobile(?:-([\\d.]))?(?:\\.min)?\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",
+      "script": "jquery[.-]mobile(?:-([\\d.]))?(?:\\.min)?\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",
       "website": "https://jquerymobile.com"
     },
     "jQuery Sparklines": {


### PR DESCRIPTION
This can be tested [here](http://docs.python-requests.org/en/master/)

- remove the `rc` thingy, since no other patter using it, and I haven't seen a
single website actually using it.
- jquery-migrate is valid too
- Remove `.*` in favour of of an optional `.min`