### PR TITLE
bootstrap: added version detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9769,7 +9769,8 @@
         "<div[^>]+class=\"[^\"]*glyphicon glyphicon-"
       ],
       "js": {
-        "bootstrap.Alert.VERSION": "(.*)\\;version:\\1"
+        "bootstrap.Alert.VERSION": "(.*)\\;version:\\1",
+        "jQuery.fn.tooltip.Constructor.VERSION": "(.*)\\;version:\\1"
       },
       "icon": "Bootstrap.svg",
       "script": [


### PR DESCRIPTION
This PR adds the detection for the bootstrap.js javascript framework for bootstrap.

Source: https://getbootstrap.com/docs/3.3/javascript/#js-version-nums