### PR TITLE
Fix a critical typo in `particules.js` detection.

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11970,7 +11970,7 @@
       "js": {
         "particleJS": ""
       },
-      "script": "/particles(?:\\min)?\\.js",
+      "script": "/particles(?:\\.min)?\\.js",
       "html": "<div id=\"particles\\-js\">",
       "website": "https://vincentgarreau.com/particles.js/"
     },


### PR DESCRIPTION
Super-duper sorry about this.