### PR TITLE
SoundManager: added version detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9116,6 +9116,7 @@
       ],
       "js": {
         "SoundManager": "",
+        "soundManager.version": "V(.+) \\;version:\\1",
         "BaconPlayer": ""
       },
       "icon": "SoundManager.png",


### PR DESCRIPTION
Adds the version detection for the Soundmanager.
Example URL: a slack workspace
Example version string to verify that the regexp works: `V2.97a.20150601 (HTML5-only mode)`

And yep, the version stored in `soundManager.version` not in the camel case one.