### PR TITLE
Add an other header to fingerprint cloudfront

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -582,7 +582,8 @@
         31
       ],
       "headers": {
-        "X-Amz-Cf-Id": ""
+        "X-Amz-Cf-Id": "",
+        "Via": "\\(CloudFront\\)$"
       },
       "icon": "Amazon-Cloudfront.svg",
       "website": "http://aws.amazon.com/cloudfront/"


### PR DESCRIPTION
This can be checked [here]( https://www.amazon.com/M-Audio-AV32-1-Professional-Multimedia-Audio-Monitor/dp/B017340ZVE )