### PR TITLE
Fix hljs detection via javascript

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -4209,7 +4209,7 @@
         19
       ],
       "js": {
-        "hljs.listLanguage": ""
+        "hljs.listLanguages": ""
       },
       "icon": "Highlight.js.png",
       "script": "/(?:([\\d.])+/)?highlight(?:\\.min)?\\.js\\;version:\\1",


### PR DESCRIPTION
Apparently, it's `hljs.listLanguages` and not `hljs.listLanguage`.
This can be verified [here](https://sigint.sh/)