### PR TITLE
remove GitPHP

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3587,17 +3587,6 @@
       },
       "website": "http://about.gitlab.com/gitlab-ci"
     },
-    "GitPHP": {
-      "cats": [
-        47
-      ],
-      "html": [
-        "<!-- gitphp web interface ([\\d.]+)\\;version:\\1",
-        "<a href=\"http://www\\.gitphp\\.org/\" target=\"_blank\">GitPHP by Chris Han"
-      ],
-      "implies": "PHP",
-      "website": "http://gitphp.org"
-    },
     "Gitiles": {
       "cats": [
         47


### PR DESCRIPTION
I propose we remove that detection. The site is for sale and I did not find the project open source so impossible to have 1000 stars.