### PR TITLE
Fix bad category for medium.com

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5960,7 +5960,7 @@
     },
     "Medium": {
       "cats": [
-        1
+        11
       ],
       "headers": {
         "X-Powered-By": "^Medium$"


### PR DESCRIPTION
Medium is a [blog](https://en.wikipedia.org/wiki/Medium_(website)), but is in the CMS category with Wappalyzer. I corrected that.