### PR TITLE
Statcounter detection was missing cases where script tag was output via document.write

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9327,6 +9327,11 @@
         10
       ],
       "icon": "StatCounter.png",
+      "js": {
+        "_statcounter": "\\;confidence:100",
+        "sc_project": "\\;confidence:50",
+        "sc_security": "\\;confidence:50"
+      },
       "script": "statcounter\\.com/counter/counter",
       "website": "http://www.statcounter.com"
     },


### PR DESCRIPTION
E.g. tag code as follows:


```
<script type="text/javascript">
var sc_project=12847410; 
var sc_invisible=1; 
var sc_security="cad283e9"; 
var sc_https=1; 
var scJsHost = (("https:" == document.location.protocol) ?
"https://secure." : "http://www.");
document.write("<sc"+"ript type='text/javascript' src='" +
scJsHost+
"statcounter.com/counter/counter.js'></"+"script>");
</script>

```