### PR TITLE
Update regex - Yii framework detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11185,7 +11185,7 @@
         "<input type=\"hidden\" value=\"[a-zA-Z0-9]{40}\" name=\"YII_CSRF_TOKEN\" \\/>",
         "<!\\[CDATA\\[YII-BLOCK-(?:HEAD|BODY-BEGIN|BODY-END)\\]"
       ],
-      "script": "yii.*\\.js",
+      "script": "yii.+\\.js",
       "icon": "Yii.png",
       "implies": [
         "PHP"


### PR DESCRIPTION
Actual Yii framework accept fake positive entry. let take Facebook as example : 
`https:\/\/static.xx.fbcdn.net\/rsrc.php\/v3\/yV\/r\/RQqbnxVLYii.js?_nc_eui2=v1\u00253AAeGyAxycoTNVHGcnXwSYhFSnxsjWmzg`

Should not be grab by regex.