### PR TITLE
remove regex for YII Framework

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11273,7 +11273,6 @@
         "<input type=\"hidden\" value=\"[a-zA-Z0-9]{40}\" name=\"YII_CSRF_TOKEN\" \\/>",
         "<!\\[CDATA\\[YII-BLOCK-(?:HEAD|BODY-BEGIN|BODY-END)\\]"
       ],
-      "script": "yii.*\\.js",
       "icon": "Yii.png",
       "implies": [
         "PHP"


### PR DESCRIPTION
Regex for script detection on YII Framework section prupose to much false positive, as prupose on https://github.com/AliasIO/Wappalyzer/pull/2246 is better to just delete it.