### PR TITLE
Tighten a bit asp and iis detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -4385,7 +4385,7 @@
         22
       ],
       "headers": {
-        "Server": "IIS(?:/([\\d.]+))?\\;version:\\1"
+        "Server": "^IIS(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "IIS.png",
       "implies": "Windows Server",
@@ -6061,7 +6061,7 @@
       },
       "headers": {
         "X-AspNet-Version": "(.+)\\;version:\\1",
-        "X-Powered-By": "ASP\\.NET\\;confidence:50"
+        "X-Powered-By": "^ASP\\.NET"
       },
       "html": "<input[^>]+name=\"__VIEWSTATE",
       "icon": "Microsoft ASP.NET.png",


### PR DESCRIPTION
- The x-powered-by header is trustworthy for ASP
- The `server` header for IIS always starts with `IIS`