### PR TITLE
Add a way to get plotly version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -7646,12 +7646,12 @@
         25
       ],
       "js": {
-        "Plotly": ""
+        "Plotly.version": "([\\d.])\\;version:\\1"
       },
       "icon": "Plotly.png",
       "implies": "D3",
       "script": "https?://cdn\\.plot\\.ly/plotly",
-      "website": "http://plot.ly/javascript/"
+      "website": "https://plot.ly/javascript/"
     },
     "Plura": {
       "cats": [


### PR DESCRIPTION
This can be tested [here]( https://whotracks.me/blog/generating_adblocker_filters.html )