### PR TITLE
Complete a0cc689e1dff9a96baf3d0488433b89d320fb062

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -10044,7 +10044,7 @@
       "icon": "Underscore.js.png",
       "js": {
         "_.restArguments": "",
-        "_.VERSION": "(.*)\\;version:\\1"
+        "_.VERSION": "(.*)\\;confidence:0\\;version:\\1"
       },
 			"excludes": "Lodash",
       "script": "underscore.*\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1",


### PR DESCRIPTION
Since lodash and underscorejs are both using `_`,
the presence of `_.VERSION` shouldn't be used
as anything else but a provider of version number