### PR TITLE
npm driver fix url filter in recursive mode. allow only urls from the same host

### DIFF
--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -146,7 +146,7 @@ class Driver {
         .then(() => {
           const links = Array.prototype.reduce.call(
             browser.document.getElementsByTagName('a'), (results, link) => {
-              if ( link.protocol.match(/https?:/) || link.hostname === this.origPageUrl.hostname || extensions.test(link.pathname) ) {
+              if ( link.protocol.match(/https?:/) && link.hostname === this.origPageUrl.hostname && extensions.test(link.pathname) ) {
                 link.hash = '';
 
                 results.push(url.parse(link.href));


### PR DESCRIPTION
Before the fix, it was gathering all the urls from facebook twitter etc and crawling them

fixing #2316