### PR TITLE
Add "wappalyzer" command (bin)

### DIFF
--- a/src/drivers/npm/index.js
+++ b/src/drivers/npm/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict';
 
 const Wappalyzer = require('./driver');

--- a/src/drivers/npm/package.json
+++ b/src/drivers/npm/package.json
@@ -16,6 +16,9 @@
     "driver.js",
     "wappalyzer.js"
   ],
+  "bin": {
+    "wappalyzer": "./index.js"
+  },
   "dependencies": {
     "request": "^2.85.0",
     "zombie": "^5.0.8"


### PR DESCRIPTION
Wappalyzer can be executed as "wappalyzer <url>" instead of "node index.js <url>".