### PR TITLE
Detect moinmoin wiki via its cookies

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -6099,6 +6099,9 @@
       "js": {
         "show_switch2gui": ""
       },
+      "cookies": {
+        "MOIN_SESSION": ""
+      },
       "icon": "MoinMoin.png",
       "implies": "Python",
       "script": "moin(?:_static(\\d)(\\d)(\\d)|.+)/common/js/common\\.js\\;version:\\1.\\2.\\3",


### PR DESCRIPTION
This can be validated [here](https://wiki.gnome.org/Initiatives/DevelopmentInfrastructure<Paste>)