### PR TITLE
Update script detection for Yii framework

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8991,7 +8991,7 @@
 				"PHP"
 			],
 			"script": "\/yii.*\\.js",
-			"website": "http://yiiframework.com"
+			"website": "https://www.yiiframework.com"
 		},
 		"Yoast SEO": {
 			"cats": [

--- a/src/apps.json
+++ b/src/apps.json
@@ -8990,6 +8990,7 @@
 			"implies": [
 				"PHP"
 			],
+			"script": "\/yii.*\\.js",
 			"website": "http://yiiframework.com"
 		},
 		"Yoast SEO": {


### PR DESCRIPTION
This PR #2252 removed the script detection because it conflicted with `https://static.xx.fbcdn.net/rsrc.php/v3/yD/r/vt21ayiiNKR.js`

I have updated the detection so it won't match that but will match the following

```
<script src="/assets/74f24751/yii.js"></script>
<script src="/assets/74f24751/yii.validation.js"></script>
<script src="/assets/74f24751/yii.activeForm.js"></script>
```

Edits and recommendations to the Regex are welcome.