### PR TITLE
Update script detection for Yii framework

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11258,7 +11258,7 @@
         "PHP"
       ],
       "script": "\/yii.*\\.js",
-      "website": "http://yiiframework.com"
+      "website": "https://www.yiiframework.com"
     },
     "Yoast SEO": {
       "cats": [

--- a/src/apps.json
+++ b/src/apps.json
@@ -11257,6 +11257,7 @@
       "implies": [
         "PHP"
       ],
+      "script": "\/yii.*\\.js",
       "website": "http://yiiframework.com"
     },
     "Yoast SEO": {

--- a/src/apps.json
+++ b/src/apps.json
@@ -11260,7 +11260,10 @@
       "implies": [
         "PHP"
       ],
-      "script": "\/yii.*\\.js",
+      "script": [
+        "\/assets\/[a-zA-Z0-9]{8}\/yii\\.*\\.js",
+        "\/assets\/[a-zA-Z0-9]{8}\/yii\\.(?:validation|activeForm)\\.js"
+      ],
       "website": "https://www.yiiframework.com"
     },
     "Yoast SEO": {

--- a/src/apps.json
+++ b/src/apps.json
@@ -11261,8 +11261,7 @@
         "PHP"
       ],
       "script": [
-        "\/assets\/[a-zA-Z0-9]{8}\/yii\\.*\\.js",
-        "\/assets\/[a-zA-Z0-9]{8}\/yii\\.(?:validation|activeForm)\\.js"
+        "\/yii(?:\\.validation|\\.activeForm){0,1}\\.js"
       ],
       "website": "https://www.yiiframework.com"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -11261,7 +11261,8 @@
         "PHP"
       ],
       "script": [
-        "\/yii(?:\\.validation|\\.activeForm){0,1}\\.js"
+        "/assets/[a-zA-Z0-9]{8}\/yii\\.js$",
+        "/yii\\.(?:validation|activeForm)\\.js"
       ],
       "website": "https://www.yiiframework.com"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -11248,6 +11248,9 @@
       "cats": [
         18
       ],
+      "cookies": {
+        "YII_CSRF_TOKEN": ""
+      },
       "html": [
         "Powered by <a href=\"http://www\\.yiiframework\\.com/\" rel=\"external\">Yii Framework</a>",
         "<input type=\"hidden\" value=\"[a-zA-Z0-9]{40}\" name=\"YII_CSRF_TOKEN\" \\/>",


### PR DESCRIPTION
PR #2252 removed the script detection because it erroneously matched `https://static.xx.fbcdn.net/rsrc.php/v3/yD/r/vt21ayiiNKR.js`

I have updated the detection so it won't match that but will match the following

```
<script src="/assets/74f24751/yii.js"></script>
<script src="/assets/74f24751/yii.validation.js"></script>
<script src="/assets/74f24751/yii.activeForm.js"></script>
```

Edits and recommendations to the Regex are welcome.