### PR TITLE
Fix confidenceTotal

### DIFF
--- a/src/wappalyzer.js
+++ b/src/wappalyzer.js
@@ -573,7 +573,7 @@ class Wappalyzer {
     app.detected = true;
 
     // Set confidence level
-    app.confidence[type + ' ' + ( key ? key + ' ' : '' ) + pattern.regex] = pattern.confidence === undefined ? 100 : pattern.confidence;
+    app.confidence[type + ' ' + ( key ? key + ' ' : '' ) + pattern.regex] = pattern.confidence === undefined ? 100 : parseInt(pattern.confidence);
 
     // Detect version number
     if ( pattern.version ) {


### PR DESCRIPTION
The confidence of a pattern is parsed as a string.

For example:
If two matching patterns have the confidence of 10, the confidenceTotal will be calculated by `'10' + '10'`, which will return `'1010'` and Wappalyzer will show it as 100% confidence and not the expected 20%.