### PR TITLE
Improve SweetAlert2 script detection, .js is optional

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9616,7 +9616,7 @@
       "excludes": "SweetAlert",
       "html": "<link[^>]+?href=\"[^\"]+sweetalert2(?:\\.min)?\\.css",
       "icon": "SweetAlert2.png",
-      "script": "sweetalert2(?:\\.all)?(?:\\.min)?\\.js",
+      "script": "sweetalert2(?:\\.all)?(?:\\.min)?(?:\\.js)?",
       "website": "https://sweetalert2.github.io/"
     },
     "Swiftlet": {


### PR DESCRIPTION
Currently, Wappalyser insn't detecting SweetAlert2 on its own homepage: https://sweetalert2.github.io/

The reason is that we're using `sweetalert2.all.min.js` from jsdelivr CDN: https://cdn.jsdelivr.net/npm/sweetalert2

This change should fix this and allow sweetalert2 detections without `.js`.