### PR TITLE
add more now.sh detectors

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -6772,7 +6772,7 @@
         "x-now-id": "",
         "x-now-cache": ""
       },
-      "url": ".+now.sh+.*",
+      "url": "^.+now.sh+.*$",
       "icon": "zeit.svg",
       "website": "https://zeit.co/now"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -6767,8 +6767,12 @@
         22
       ],
       "headers": {
-        "server": "^now$"
+        "server": "^now$",
+        "x-now-trace": "",
+        "x-now-id": "",
+        "x-now-cache": ""
       },
+      "url": ".+now.sh+.*",
       "icon": "zeit.svg",
       "website": "https://zeit.co/now"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -6772,7 +6772,6 @@
         "x-now-id": "",
         "x-now-cache": ""
       },
-      "url": "^.+now.sh+.*$",
       "icon": "zeit.svg",
       "website": "https://zeit.co/now"
     },


### PR DESCRIPTION
The reason is that now.sh started using 'cloudflare' header but also have own and wappalyzer can recognize them.