### PR TITLE
Updating ExtJS

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2923,10 +2923,11 @@
       "icon": "ExtJS.png",
       "js": {
         "Ext": "",
+        "Ext.version": "(.*)\\;version:\\1",
         "Ext.versions.extjs.version": "(.*)\\;version:\\1"
       },
       "script": "ext-base\\.js",
-      "website": "http://www.extjs.com"
+      "website": "https://www.sencha.com"
     },
     "FAST ESP": {
       "cats": [


### PR DESCRIPTION
Updating the link to ExtJS website (now Sencha), as well as updating the mechanism to detect older versions of the framework (specifically 2.x and 3.x)