### PR TITLE
Improve the detection of jquery-migrate

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11764,9 +11764,11 @@
       "icon": "jQuery.svg",
       "implies": "jQuery",
       "js": {
-        "jQuery.migrateVersion": "([\\d.]+)\\;version:\\1"
+        "jQuery.migrateVersion": "([\\d.]+)\\;version:\\1",
+        "jQuery.migrateWarnings": "",
+        "jqueryMigrate": ""
       },
-      "script": "jquery[.-]migrate(?:-([\\d.]))?(?:\\.min)?\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",
+      "script": "jquery[.-]migrate(?:-([\\d.]+))?(?:\\.min)?\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1?\\1:\\2",
       "website": "https://github.com/jquery/jquery-migrate"
     },
     "jQuery Mobile": {


### PR DESCRIPTION
- Detect legacy version of jquery version.
  This can be tested [here](https://snuffleupagus.readthedocs.io/features.html)
- Fix the regexp in the `script` detection