### PR TITLE
Fix? js confidence calculation

### DIFF
--- a/src/wappalyzer.js
+++ b/src/wappalyzer.js
@@ -657,7 +657,7 @@ class Wappalyzer {
           const value = results[string][index];
 
           if (pattern && pattern.regex.test(value)) {
-            addDetected(app, pattern, 'js', value);
+            addDetected(app, pattern, 'js', value, string);
           }
         }));
       }


### PR DESCRIPTION
I'm not sure if this is an error or not, sorry if it isn't.
But js confidence calculation was different from cookie and headers and meta by not providing a key value, even though it has the same schema of a dict in apps.json as headers/cookies/meta
Maybe I'm not seeing something and you can't use string variable name here.