### PR TITLE
Fix Issue 2419

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3665,7 +3665,7 @@
         "GoogleAnalyticsObject": "",
         "gaGlobal": ""
       },
-      "script": "google-analytics\\.com\\/(?:ga|urchin|(analytics))\\.js\\;version:\\1?Universal Analytics:",
+      "script": "google-analytics\\.com\\/(?:ga|urchin|analytics)\\.js",
       "website": "http://google.com/analytics"
     },
     "Google Analytics Enhanced eCommerce": {


### PR DESCRIPTION
Removed seemingly unnecessary capturing group and non-numeric version tag in Google Analytics pattern to prevent falsely reporting "analytics" or "Universal Analytics" as a version identifier.

I understand that there are `classic` (deprecated) and `universal` flavors offered (at some point) by Google so if you want this split into two different patterns let me know and I can tackle that too. However, with this not being what the majority in the IT industry would classify as a "version" identifier I figured this was a safe way to go.

Fixes AliasIO/Wappalyzer#2419