### PR TITLE
Improve the detection of vBulleting via cookies

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -12414,6 +12414,11 @@
       "js": {
         "vBulletin": ""
       },
+      "cookies": {
+        "bbsessionhash": "",
+        "bblastactivity": "",
+				"bblastvisit": ""
+      },
       "meta": {
         "generator": "vBulletin ?([\\d.]+)?\\;version:\\1"
       },


### PR DESCRIPTION
This is documented [here](https://cookiepedia.co.uk/cookies/bbsessionhash) and [here](https://www.trafford.gov.uk/residents/Cookie-policy.aspx) and can be tested [here](https://www.mobileread.com/forums/showthread.php?t=284418).