### PR TITLE
Delete unexpected coma

### DIFF
--- a/src/drivers/webextension/js/lib/iframe.js
+++ b/src/drivers/webextension/js/lib/iframe.js
@@ -139,7 +139,7 @@
             } else {
               elseCallback();
             }
-          },
+          }
         );
       },
     };


### PR DESCRIPTION
Fix bug with unexpected coma after the last function parameter
Google Chrome console error:
``` iframe.js:143 Uncaught SyntaxError: Unexpected token ) ```