### PR TITLE
Relax a bit tomcat detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -735,7 +735,7 @@
         22
       ],
       "headers": {
-        "Server": "^Apache-Coyote(/1\\.1)?$\\;version:\\1?4.1+:",
+        "Server": "^Apache-Coyote",
         "X-Powered-By": "\\bTomcat\\b(?:-([\\d.]+))?\\;version:\\1"
       },
       "icon": "Apache Tomcat.svg",


### PR DESCRIPTION
There might be some trailing text after "Apache-Coyote",
like on <https://espace-client.sfr.fr/services-web/>

Also, the 4.1+ thingy is useless, often confusing,
sometimes wrong, and is a bit irrelevant in 2018 since
Tomcat 4.1 was declared stable in 2002,
with its last release in 2009.