### PR TITLE
Fix IIS regex

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -4281,7 +4281,7 @@
         22
       ],
       "headers": {
-        "Server": "^(:?Microsoft-)?IIS(?:/([\\d.]+))?\\;version:\\1"
+        "Server": "^(?:Microsoft-)?IIS(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "IIS.png",
       "implies": "Windows Server",

--- a/src/apps.json
+++ b/src/apps.json
@@ -4281,7 +4281,7 @@
         22
       ],
       "headers": {
-        "Server": "IIS(?:/([\\d.]+))?\\;version:\\1"
+        "Server": "^(:?Microsoft-)?IIS(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "IIS.png",
       "implies": "Windows Server",

--- a/src/apps.json
+++ b/src/apps.json
@@ -4281,7 +4281,7 @@
         22
       ],
       "headers": {
-        "Server": "^IIS(?:/([\\d.]+))?\\;version:\\1"
+        "Server": "IIS(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "IIS.png",
       "implies": "Windows Server",


### PR DESCRIPTION
I don't know if it's new, but webserver return `Microsoft-IIS/8.5` in the `Server` header and not `IIS[0-9]+`. 

You can find an example here : https://login.live.com/