### PR TITLE
[bug fix] Allow analyzeCookies to check for cookies with Uppercase names

### DIFF
--- a/src/wappalyzer.js
+++ b/src/wappalyzer.js
@@ -629,10 +629,10 @@ class Wappalyzer {
 
     Object.keys(patterns).forEach((cookieName) => {
       if (typeof patterns[cookieName] !== 'function') {
-        cookieName = cookieName.toLowerCase();
+        const cookieNameLower = cookieName.toLowerCase();
 
         promises.push(asyncForEach(patterns[cookieName], (pattern) => {
-          const cookie = cookies.find(_cookie => _cookie.name.toLowerCase() === cookieName);
+          const cookie = cookies.find(_cookie => _cookie.name.toLowerCase() === cookieNameLower);
 
           if (cookie && pattern.regex.test(cookie.value)) {
             addDetected(app, pattern, 'cookies', cookie.value, cookieName);

--- a/src/wappalyzer.spec.js
+++ b/src/wappalyzer.spec.js
@@ -12,6 +12,11 @@ const appsJson = {
       test: 'test',
     },
   },
+  appUppercaseCookies: {
+    cookies: {
+      Test: 'Test',
+    },
+  },
   appHeaders: {
     headers: {
       'X-Powered-By': 'test',
@@ -109,6 +114,7 @@ describe('Wappalyzer', () => {
 
     it('should identify technologies using cookies', () => {
       expect(apps).to.have.any.keys('appCookies');
+      expect(apps).to.have.any.keys('appUppercaseCookies');
     });
 
     it('should identify technologies using JavaScript', () => {

--- a/src/wappalyzer.spec.js
+++ b/src/wappalyzer.spec.js
@@ -114,6 +114,9 @@ describe('Wappalyzer', () => {
 
     it('should identify technologies using cookies', () => {
       expect(apps).to.have.any.keys('appCookies');
+    });
+
+    it('should identify technologies using uppercase named cookies', () => {
       expect(apps).to.have.any.keys('appUppercaseCookies');
     });
 


### PR DESCRIPTION
Right now analyzeCookies can't handle cookies with uppercase cookie names, such as `AFRAME.version` for A-Frame (since it looks for the lowercase name in `patterns` on line 634). This is a quick fix for that.
