### PR TITLE
Detect Google Analytics if AMP is used

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3675,6 +3675,7 @@
         "_gat": ""
       },
       "icon": "Google Analytics.svg",
+			"html": "<amp-analytics [^>]*type=[\"']googleanalytics[\"']",
       "js": {
         "GoogleAnalyticsObject": "",
         "gaGlobal": ""


### PR DESCRIPTION
This can be verified [here](view-source:https://www.konbini.com/fr/entertainment-2/tommy-wiseau-rejoue-joker-cest-mauvais-the-room/amp/)