### PR TITLE
improve detection docusaurus

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2531,6 +2531,9 @@
         "React",
         "webpack"
       ],
+      "js": {
+        "search.indexName": ""
+      },
       "meta": {
         "generator": "^Docusaurus$"
       },


### PR DESCRIPTION
This technology is not detected on all sites that use it. 
For example, it is detected on this site (https://draftjs.org/) but not on this one (https://docusaurus.io)

With this improvement, it is detected at more sites.