### PR TITLE
Tighten a bit nelify detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -6656,8 +6656,8 @@
         31
       ],
       "headers": {
-        "x-nf-request-id": "",
-        "Server": "Netlify"
+        "X-NF-Request-ID": "",
+        "Server": "^Netlify"
       },
       "icon": "Netlify.svg",
       "website": "https://www.netlify.com/"


### PR DESCRIPTION
- The server header always _start_ with Netlify
- Change the capitalization of the x-nf-request-id header