### PR TITLE
Improve FluxBB detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3202,10 +3202,10 @@
       "cats": [
         2
       ],
-      "html": "Powered by (?:<strong>)?<a href=\"[^>]+fluxbb",
+      "html": "<p id=\"poweredby\">[^<]+<a href=\"https?://fluxbb\\.org/\">",
       "icon": "FluxBB.png",
       "implies": "PHP",
-      "website": "http://fluxbb.org"
+      "website": "https://fluxbb.org"
     },
     "Flyspray": {
       "cats": [


### PR DESCRIPTION
- Wappalyzer is now able to detect localized fluxbb forums, like [this one](http://www.hellfest-forum.fr/)
- use https for the website