### PR TITLE
Sphinx doesn't imply Python

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9248,7 +9248,6 @@
       ],
       "html": "Created using <a href=\"https?://sphinx-doc\\.org/\">Sphinx</a> ([.\\d+])+\\.\\;version:\\1",
       "icon": "Sphinx.png",
-      "implies": "Python",
       "js": {
         "DOCUMENTATION_OPTIONS": ""
       },


### PR DESCRIPTION
Python is used to compile the markdown/ReST to
html, but it doesn't mean that the page is _served_
using Python.