### PR TITLE
Detect wordpress sites, even if they're using amp

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -10906,6 +10906,7 @@
       ],
       "html": [
         "<link rel=[\"']stylesheet[\"'] [^>]+wp-(?:content|includes)",
+				"<div[^>]*class=[\"']amp-wp-",
         "<link[^>]+s\\d+\\.wp\\.com"
       ],
       "icon": "WordPress.svg",


### PR DESCRIPTION
This can be tested [here](view-source:https://www.konbini.com/fr/entertainment-2/tommy-wiseau-rejoue-joker-cest-mauvais-the-room/amp/)