### PR TITLE
Remove split / concat when htmlMaxRows and htmlMaxCols is 0

### DIFF
--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -282,13 +282,17 @@ class Driver {
     let html = '';
 
     try {
-      html = browser.html()
-        .replace(new RegExp(`(.{${this.options.htmlMaxCols},}[^>]*>)<`, 'g'), (match, p1) => `${p1}\n<`)
-        .split('\n')
-        .slice(0, this.options.htmlMaxRows / 2)
-        .concat(html.slice(html.length - this.options.htmlMaxRows / 2))
-        .map(line => line.substring(0, this.options.htmlMaxCols))
-        .join('\n');
+      if ((this.options.htmlMaxCols === 0) && (this.options.htmlMaxRows === 0)) {
+        html = browser.html().replace(new RegExp('<', 'g'), '\n<');
+      } else {
+        html = browser.html()
+          .replace(new RegExp(`(.{${this.options.htmlMaxCols},}[^>]*>)<`, 'g'), (match, p1) => `${p1}\n<`)
+          .split('\n')
+          .slice(0, this.options.htmlMaxRows / 2)
+          .concat(html.slice(html.length - this.options.htmlMaxRows / 2))
+          .map(line => line.substring(0, this.options.htmlMaxCols))
+          .join('\n');
+      }
     } catch (error) {
       this.wappalyzer.log(error.message, 'browser', 'error');
     }


### PR DESCRIPTION
The htmlMaxCols and htmlMaxRows related regex can take a lot of time, this PR implements a shortcut to ignore that functionality when htmlMaxRows and htmlMaxCols is set to 0. 

This one also solves the problem with #2530 as far as I can tell.