### PR TITLE
improve tray regex

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9978,7 +9978,7 @@
         6
       ],
       "icon": "tray.png",
-      "script": ".+tcdn\\.com\\.br",
+      "script": "tcdn\\.com\\.br",
       "website": "https://www.tray.com.br"
     },
     "Tumblr": {


### PR DESCRIPTION
This `.+` on the regex kill the performance on very big `script`