### PR TITLE
Optimize a bit oscommerce detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -12142,7 +12142,11 @@
       "cookies": {
         "osCsid": ""
       },
-      "html": "(?:<a[^>]*(?:\\?|&)osCsid|Powered by (?:<[^>]+>)?osCommerce</a>|<[^>]+class=\"[^>]*infoBoxHeading)",
+      "html": [
+				"<br />Powered by <a href=\"https?://www\\.oscommerce\\.com",
+				"<(?:input|a)[^>]+name=\"osCsid\"",
+				"<(?:tr|td|table)class=\"[^\"]*infoBoxHeading"
+			],
       "icon": "osCommerce.png",
       "implies": [
         "PHP",


### PR DESCRIPTION
- Split the regexp in 3 parts
- Improve a regex, accordingly to the [source code](https://github.com/osCommerce/oscommerce/blob/1705380eadfd14572764ba7c783d75951ef9d299/osCommerce/OM/Core/Site/Shop/Languages/en_US.xml#L205) of oscommerce
- Fix some mistakes