### PR TITLE
Update styled-components detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -12435,7 +12435,10 @@
         12,
         47
       ],
-      "html": "<style[^>]*data-styled",
+      "html": [
+        "<style[^>]*data-styled(?:-components)?[\\s\"]",
+        "<style[^>]+data-styled-version=\"([0-9)+)\"\\;version:\\1"
+      ],
       "icon": "styled-components.png",
       "implies": [
         "React"

--- a/src/apps.json
+++ b/src/apps.json
@@ -12437,7 +12437,7 @@
       ],
       "html": [
         "<style[^>]*data-styled(?:-components)?[\\s\"]",
-        "<style[^>]+data-styled-version=\"([0-9)+)\"\\;version:\\1"
+        "<style[^>]+data-styled-version=\"([0-9]+)\"\\;version:\\1"
       ],
       "icon": "styled-components.png",
       "implies": [

--- a/src/apps.json
+++ b/src/apps.json
@@ -12435,7 +12435,7 @@
         12,
         47
       ],
-      "html": "<style[^>]*data-styled-components",
+      "html": "<style[^>]*data-styled",
       "icon": "styled-components.png",
       "implies": [
         "React"


### PR DESCRIPTION
> This value overrides the default <style> tag attribute, data-styled (data-styled components in v3 and lower). 

It looks like the newer versions of styled-components use `data-styled` instead of `data-styled-components`:

![](https://imgur.com/ypkUNGj.png)

Live example: https://kepinski.me (my site)

I think it would be a good idea to keep the old detection too, but I don't know how to use 2 HTML detections at once :cry: