### PR TITLE
Change MAINTAINER to LABEL instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-MAINTAINER Elbert Alias <elbert@alias.io>
+LABEL maintainer="elbert@alias.io"
 
 ENV WAPPALYZER_DIR=/opt/wappalyzer
 


### PR DESCRIPTION
`MAINTAINER` instructions is [deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated), should use `LABEL` instead `MAINTAINER`.