### PR TITLE
Add webzi site builder

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11005,6 +11005,20 @@
       ],
       "website": "https://www.weglot.com"
     },
+    "Webzi": {
+      "cats": [
+        1
+      ],
+      "icon": "Webzi.svg",
+      "js": {
+        "Webzi": ""
+      },
+      "meta": {
+        "generator": "^Webzi"
+      },
+      "script": "cdn\\.6th\\.ir",
+      "website": "https://webzi.ir"
+    },
     "Wikinggruppen": {
       "cats": [
         6


### PR DESCRIPTION
Hello.
Have a nice time
Please add Webzi to apps.json
300 websites are built using Webzi.
Webzi Logo: https://webzi.ir/logo.svg
Check dns lookup
http://reversens.domaintools.com/search/?q=webzidns.ir
Sample sites:
http://iefm.eu
http://nikaniroo.com
https://paverzz.com
http://pishrooabrpars.com
https://veggie-snack.com
http://deltatechnicalgroup.com
https://berenjonline.com
http://coopalbag.com
http://mehrakco.com
http://banesell.com
http://amoghnad.com
http://dekland.com
https://fardingraphic.ir
http://mohsena.ir
http://samashimi.ir
http://yasilyol.ir