### PR TITLE
Fix Botble CMS's version detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5825,7 +5825,7 @@
         "botble_session": ""
       },
       "headers": {
-        "CMS-Version": "^(.+)$\\;version:\\1;confidence:0"
+        "CMS-Version": "^(.+)$\\;version:\\1\\;confidence:0"
       },
       "icon": "mypage-platform.png",
       "implies": "Laravel",


### PR DESCRIPTION
Current issue:
<img width="676" alt="screenshot at feb 12 23-01-21" src="https://user-images.githubusercontent.com/6972407/52649079-310b7380-2f1a-11e9-8fcc-ed42d2692875.png">
