### PR TITLE
Update All-in-One SEO url

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -491,7 +491,7 @@
       "html": "<!-- All in One SEO Pack ([\\d.]+) \\;version:\\1",
       "icon": "all-in-One-SEO-Pack.png",
       "implies": "WordPress",
-      "website": "https://www.acquia.com/"
+      "website": "https://wordpress.org/plugins/all-in-one-seo-pack/"
     },
     "Allegro RomPager": {
       "cats": [


### PR DESCRIPTION
fixes #2655

Replace the Acquia.com URL (which is a web hosting company) with the WordPress plugin URL.