### PR TITLE
Add Platform.sh

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -7782,6 +7782,19 @@
       },
       "website": "https://www.platform-os.com"
     },
+    "Platform.sh": {
+      "cats": [
+        62
+      ],
+      "icon": "platformsh.svg",
+      "headers": {
+        "x-platform-cluster": "",
+        "x-platform-processor": "",
+        "x-platform-router": "",
+        "x-platform-server": ""
+      },
+      "website": "https://platform.sh"
+    },
     "Play": {
       "cats": [
         18

--- a/src/icons/platformsh.svg
+++ b/src/icons/platformsh.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 43 43" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <g transform="matrix(1.5,0,0,1.5,0,0)">
+        <rect x="0" y="0" width="28.55" height="28.37" style="fill:rgb(33,37,41);"/>
+        <g>
+            <g transform="matrix(0.821308,0,0,0.821308,-115.775,1.83776)">
+                <rect x="144.07" y="0.849" width="28.55" height="11.272" style="fill:white;fill-rule:nonzero;"/>
+            </g>
+            <g transform="matrix(0.821308,0,0,0.821308,-115.775,1.83776)">
+                <rect x="144.07" y="25.379" width="28.55" height="3.84" style="fill:white;fill-rule:nonzero;"/>
+            </g>
+            <g transform="matrix(0.821308,0,0,0.821308,-115.775,1.83776)">
+                <rect x="144.07" y="15.766" width="28.55" height="5.784" style="fill:white;fill-rule:nonzero;"/>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Platform.sh is a cloud PaaS provider for application hosting (similar to Heroku, Now, Acquia, Pantheon, and others) who is currently the dedicated hosting partner for Magento Commerce Cloud (aka Magento Enterprise). Platform.sh utilizes AWS and Microsoft Azure as their infrastructure backbone, but it’s difficult to imply either since it seems to be based on region.

- https://platform.sh
- https://github.com/platformsh
- https://www.britishcouncil.us
- https://www.centarro.io
- https://commerceguys.com
- https://drupalcommerce.org
- https://www.rossignol.com/us
- https://egoshoes.com
- https://www.ospreylondon.com

Most sites running Magento Commerce Cloud will be running on Platform.sh.

https://magento.com/case-studies?product=magento-commerce-cloud