### PR TITLE
Fix OpenCart false positive

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -7235,7 +7235,9 @@
       "cats": [
         6
       ],
-      "html": "(?:index\\.php\\?route=[a-z]+/|Powered By <a href=\"[^>]+OpenCart)",
+      "cookies": {
+        "OCSESSID": ""
+      },
       "icon": "OpenCart.png",
       "implies": "PHP",
       "website": "http://www.opencart.com"


### PR DESCRIPTION
This replaces the loose HTML lookup (which just looks for a link with "OpenCart"), which is why it shows up in Google because it's in a search result.

Instead, we can use the OCSESSID cookie that's issued by OpenCart.

**Fixes Google search results**
![image](https://user-images.githubusercontent.com/1759794/56373004-b08d1b80-61c5-11e9-8220-721e91d6c472.png)

**Works in OpenCart demos**
![image](https://user-images.githubusercontent.com/1759794/56373060-c7cc0900-61c5-11e9-8ef6-b59fa069f083.png)


fixes #2650