### PR TITLE
Expand cookie domain by parsing for root domain

### DIFF
--- a/src/drivers/webextension/html/background.html
+++ b/src/drivers/webextension/html/background.html
@@ -5,6 +5,7 @@
 		<meta charset="utf-8">
 
 		<script src="../node_modules/webextension-polyfill/dist/browser-polyfill.js"></script>
+		<script src="../node_modules/tldts/dist/tldts.umd.min.js"></script>
 		<script src="../js/wappalyzer.js"></script>
 		<script src="../js/driver.js"></script>
 		<script src="../js/lib/network.js"></script>

--- a/src/drivers/webextension/html/options.html
+++ b/src/drivers/webextension/html/options.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="../css/options.css">
 
     <script src="../node_modules/webextension-polyfill/dist/browser-polyfill.js"></script>
+    <script src="../node_modules/tldts/dist/tldts.umd.min.js"></script>
     <script src="../js/wappalyzer.js"></script>
     <script src="../js/options.js"></script>
   </head>

--- a/src/drivers/webextension/js/driver.js
+++ b/src/drivers/webextension/js/driver.js
@@ -148,7 +148,7 @@ browser.runtime.onConnect.addListener((port) => {
 
     const url = wappalyzer.parseUrl(port.sender.tab ? port.sender.tab.url : '');
 
-    const cookies = await browser.cookies.getAll({ domain: `.${url.hostname}` });
+    const cookies = await browser.cookies.getAll({ domain: `.${url.domain}` });
 
     let response;
 

--- a/src/drivers/webextension/npm-shrinkwrap.json
+++ b/src/drivers/webextension/npm-shrinkwrap.json
@@ -2,6 +2,11 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "tldts": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-4.0.6.tgz",
+      "integrity": "sha512-Or/FylLxfHc/vXMN0XTrY3MDlGqyeUIB1AYTN2QV2fnKJ3ZEpM4iTTofv8AdA09UbZtsPmvcSk841kpDqbM6bg=="
+    },
     "webextension-polyfill": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.4.0.tgz",

--- a/src/drivers/webextension/package.json
+++ b/src/drivers/webextension/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "tldts": "^4.0.6",
     "webextension-polyfill": "^0.4.0"
   }
 }

--- a/src/wappalyzer.js
+++ b/src/wappalyzer.js
@@ -285,10 +285,13 @@ class Wappalyzer {
    */
   parseUrl(url) {
     const a = this.driver.document.createElement('a');
+    const u = tldts.parse(url);
 
     a.href = url;
 
     a.canonical = `${a.protocol}//${a.host}${a.pathname}`;
+
+    a.domain = u.domain;
 
     return a;
   }


### PR DESCRIPTION
- Implements TLDTS library
- Accounts for SLD domains (.co.uk, .org.nz, etc)
- Returns as part of domain element from parseUrl function

refers to #2676

With this solution, we're able to parse the URL for the root domain, while also accounting for SLD domains. This will give Wappalyzer a broader scope to detect, while also still limiting the information to the target domain.

We're able to achieve this by using the [TLDTS](https://www.npmjs.com/package/tldts) library, which claims to be the fastest domain processing library. 

> `tldts` is the **fastest JavaScript library available for parsing hostnames**. It is able to parse up to 2M hostnames per second on a modern i7-8550U CPU with Node.js version 11.6.0.

This library also has 0 dependencies, making it ideal to reduce overall package size and limit liability.

**Below: showing the spectrum of cookies related to the domain that can be detected**
![Screen Shot 2019-04-19 at 1 54 18 PM](https://user-images.githubusercontent.com/1759794/56440139-266cb200-62ae-11e9-97e0-981586e376a2.png)
