### PR TITLE
Add official AMP plugin for WordPress

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -125,7 +125,7 @@
         "WordPress"
       ],
       "meta": {
-        "generator": "^AMP Plugin v\\d+\\.\\d+"
+        "generator": "^AMP Plugin v(\\d+\\.\\d+.*?)(?:;\\s*mode=(\\w+))?$"
       },
       "website": "https://amp-wp.org"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -125,7 +125,7 @@
         "WordPress"
       ],
       "meta": {
-        "generator": "^AMP Plugin v(\\d+\\.\\d+.*?)(?:;\\s*mode=(\\w+))?(?:;\\s*experiences=(\\w+))?$\\;version:\\1\\;mode:\\2\\;experiences:\\3"
+        "generator": "^AMP Plugin v(\\d+\\.\\d+.*)$\\;version:\\1"
       },
       "website": "https://amp-wp.org"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -11506,7 +11506,6 @@
       ],
       "html": [
         "<link rel=[\"']stylesheet[\"'] [^>]+/wp-(?:content|includes)/",
-        "<div[^>]*class=[\"']amp-wp-",
         "<link[^>]+s\\d+\\.wp\\.com"
       ],
       "icon": "WordPress.svg",

--- a/src/apps.json
+++ b/src/apps.json
@@ -115,6 +115,20 @@
       "icon": "Accelerated-Mobile-Pages.svg",
       "website": "https://www.ampproject.org"
     },
+    "AMP Plugin": {
+      "cats": [
+        1,
+        11
+      ],
+      "icon": "Accelerated-Mobile-Pages.svg",
+      "implies": [
+        "WordPress"
+      ],
+      "meta": {
+        "generator": "^AMP Plugin v\\d+\\.\\d+"
+      },
+      "website": "https://amp-wp.org"
+    },
     "Azure": {
       "cats": [
         62

--- a/src/apps.json
+++ b/src/apps.json
@@ -125,7 +125,7 @@
         "WordPress"
       ],
       "meta": {
-        "generator": "^AMP Plugin v(\\d+\\.\\d+.*?)(?:;\\s*mode=(\\w+))?$"
+        "generator": "^AMP Plugin v(\\d+\\.\\d+.*?)(?:;\\s*mode=(\\w+))?(?:;\\s*experiences=(\\w+))?$\\;version:\\1\\;mode:\\2\\;experiences:\\3"
       },
       "website": "https://amp-wp.org"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -118,7 +118,7 @@
     "AMP Plugin": {
       "cats": [
         1,
-        11
+        5
       ],
       "icon": "Accelerated-Mobile-Pages.svg",
       "implies": [


### PR DESCRIPTION
Add detection for sites running the official AMP plugin for WordPress: https://amp-wp.org/

Not sure about the best categories, so right now it's just re-using the WordPress categories.

This PR also removes the `<div[^>]*class=[\"']amp-wp-` check from the WordPress detection, as it seems overly suspect to false positives.