### PR TITLE
Update Doxygen homepage

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2799,7 +2799,7 @@
       "meta": {
         "generator": "Doxygen ([\\d.]+)\\;version:\\1"
       },
-      "website": "http://www.stack.nl/~dimitri/doxygen/"
+      "website": "http://www.doxygen.nl/"
     },
     "DreamWeaver": {
       "cats": [


### PR DESCRIPTION
Because the previous hoster decided to disband itself, Doxygen moved to its own domain. Site linked on https://github.com/doxygen/doxygen