### PR TITLE
Update detection for Shopify storefronts

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9274,11 +9274,16 @@
       "cats": [
         6
       ],
-      "html": "<link[^>]+=['\"]//cdn\\.shopify\\.com",
+      "html": "<link[^>]+=['\"]//cdn\\.shopify\\.com\\;confidence:25",
       "icon": "Shopify.svg",
       "js": {
-        "Shopify": ""
+        "Shopify": "\\;confidence:25"
       },
+      "headers": {
+        "x-shopid": "*\\;confidence:50",
+        "x-shopify-stage": "*\\;confidence:50"
+      },
+      "url": "^https?//.+\\.myshopify\\.com",
       "website": "http://shopify.com"
     },
     "Shopline": {

--- a/src/drivers/npm/npm-shrinkwrap.json
+++ b/src/drivers/npm/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "wappalyzer",
-  "version": "5.8.1",
+  "version": "5.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Followup to email from @rviscomi about [Web Almanac](https://github.com/HTTPArchive/almanac.httparchive.org)

Updates Shopify detection with:
- Reduced confidence with file references to `cdn.shopify.com`
- Reduced confidence with declaration of `window.Shopify`
- Look for `x-shopid` and `x-shopify-stage` headers
- If origin is `myshopify.com`, then we know the website is built with Shopify.

This should also remove `shopify.com` websites (used for Shopify marketing) from detection -- does that make sense for Wappalyzer?

I ran `./run validate` but had several errors from other applications that I didn't touch? 🤷‍♂️