### PR TITLE
Make AMP detection slightly more robust

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -107,13 +107,13 @@
       },
       "website": "http://awstats.sourceforge.net"
     },
-    "Accelerated Mobile Pages": {
+    "AMP": {
       "cats": [
         12
       ],
-      "html": "<html[^>]* (?:amp|⚡)",
+      "html": "<html[^>]* (?:amp|⚡)[^-]",
       "icon": "Accelerated-Mobile-Pages.svg",
-      "website": "https://www.ampproject.org"
+      "website": "https://www.amp.dev"
     },
     "Azure": {
       "cats": [


### PR DESCRIPTION
The AMP detection causes false positives with sites that didn't have the amp attribute in the `<html>` tag, but loaded an AMP related script, as AMP's JS adds dynamic amp-* attributes to the `<html>`.

This also updates our name (now just AMP), and the website (now amp.dev).