### PR TITLE
Check for HTMLAnchorElement properties on links

### DIFF
--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -242,6 +242,15 @@ class Driver {
 
     const reducedLinks = Array.prototype.reduce.call(
       browser.links, (results, link) => {
+        // Catch broken links.
+        if (!link.protocol) {
+          this.wappalyzer.log("Element is not a valid link interface.", "driver", "error");
+          return;
+        }
+        if (results == null || !results.hasOwnProperty("push")) {
+          this.wappalyzer.log("Result object is not an array.", "driver", "error");
+          return;
+        }
         if (link.protocol.match(/https?:/) && link.hostname === this.origPageUrl.hostname && extensions.test(link.pathname)) {
           link.hash = '';
 


### PR DESCRIPTION
- Also check in the case when results are undefined or not of array type
- Only logs error and skips. Throw Error/Catch returns no data
- fixes #2694