### PR TITLE
Remove collision between Ant Design (React vs Vue)

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -774,9 +774,6 @@
         "<i class=\"anticon anticon-"
       ],
       "icon": "Ant Design.svg",
-      "implies": [
-        "React"
-      ],
       "js": {
         "antd": ""
       },


### PR DESCRIPTION
- There’s no defining characteristic to determine whether Ant Design is React or Vue, so it’s best to check those on their own fingerprints and leave Ant by itself.
- fixes #2680