### PR TITLE
Update styled-components identification on injected CSS

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -13138,7 +13138,8 @@
       ],
       "html": [
         "<style[^>]*data-styled(?:-components)?[\\s\"]",
-        "<style[^>]+data-styled-version=\"([0-9]+)\"\\;version:\\1"
+        "<style[^>]+data-styled-version=\"([0-9]+)\"\\;version:\\1",
+        "sc-component-id: sc-"
       ],
       "icon": "styled-components.png",
       "implies": [


### PR DESCRIPTION
Noticed styled hasn't been being registered on most of the projects I use it on.   On SSR projects, all of the generated hashed classes will have the following declaration:

Example:
`/* sc-component-id: sc-1v848in-0 */`