### PR TITLE
CrossBox fix

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2426,7 +2426,7 @@
       ],
       "icon": "CrossBox.png",
       "headers": {
-        "server": "CBX-WS",
+        "server": "CBX-WS"
       },
       "website": "https://crossbox.io"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -2425,7 +2425,9 @@
         30
       ],
       "icon": "CrossBox.png",
-      "html": "<span class=\"product-name-loading\">CrossBox Premium Webmail",
+      "headers": {
+        "server": "CBX-WS",
+      },
       "website": "https://crossbox.io"
     },
     "Crypto-Loot": {


### PR DESCRIPTION
Correction to detect Crossbox via the "server" header.  The current HTML match doesn't work for the white-labeled instances.