### PR TITLE
Apps.json file modified due to wrong detection of technologies.

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3242,7 +3242,7 @@
         18,
         59
       ],
-      "html": "<[^>]+ class ?= ?['|\"](e-control|[^\"]+ e-control)\\b[^\"]* e-lib\\b",
+      "html": "<[^>]+ class ?= ?\"(?:e-control|[^\"]+ e-control)(?: )[^\"]* e-lib\\b",
       "icon": "syncfusion.svg",
       "website": "https://www.syncfusion.com/javascript-ui-controls"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -3242,7 +3242,7 @@
         18,
         59
       ],
-      "html": "<[^>]+ class ?= ?\"(e-control|[^\"]+ e-control)(?= )[^\"]* e-lib\\b",
+      "html": "<[^>]+ class ?= ?['|\"](e-control|[^\"]+ e-control)(?= )[^\"]* e-lib\\b",
       "icon": "syncfusion.svg",
       "website": "https://www.syncfusion.com/javascript-ui-controls"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -3242,7 +3242,7 @@
         18,
         59
       ],
-      "html": "<[^>]+ class ?= ?['|\"](e-control|[^\"]+ e-control)(?= )[^\"]* e-lib\\b",
+      "html": "<[^>]+ class ?= ?['|\"](e-control|[^\"]+ e-control)\\b[^\"]* e-lib\\b",
       "icon": "syncfusion.svg",
       "website": "https://www.syncfusion.com/javascript-ui-controls"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -3242,7 +3242,7 @@
         18,
         59
       ],
-      "html": "<[^<]+class=\"[^\"]*[^-](?:e-control|e-lib)",
+      "html": "<[^>]+ class ?= ?\"(e-control|[^\"]+ e-control)(?= )[^\"]* e-lib\\b",
       "icon": "syncfusion.svg",
       "website": "https://www.syncfusion.com/javascript-ui-controls"
     },


### PR DESCRIPTION
Hi @AliasIO ,

Finally, I could see the resultant detection from yesterday, but those results were listing out few wrong detection of technologies as well. Therefore, I have added the optimal html pattern now which will help me to detect the exact technologies. Can you please merge it to help me in retrieving the exact matching list of technologies. Thanks in advance for your help.

Modified pattern is to match the HTML elements with the exact class names including both the terms "e-control" and "e-lib" as mandatory. Previously mistook that the word boundary were not supported and therefore, now corrected it.

Ensured now using the puppeteer. Apologize for the inconveniences.

Regards,
C. Uma Maheswari