### PR TITLE
Add Simple Analytics

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9627,6 +9627,13 @@
       "implies": "PHP",
       "website": "https://www.silverstripe.org"
     },
+    "Simple Analytics": {
+      "cats": [
+        10
+      ],
+      "icon": "SimpleAnalytics.svg",
+      "script": "^https:\\/\\/cdn\\.simpleanalytics\\.io\\/hello\\.js",
+      "website": "https://simpleanalytics.com"
     "SimpleHTTP": {
       "cats": [
         22

--- a/src/apps.json
+++ b/src/apps.json
@@ -9634,6 +9634,7 @@
       "icon": "SimpleAnalytics.svg",
       "script": "^https:\\/\\/cdn\\.simpleanalytics\\.io\\/hello\\.js",
       "website": "https://simpleanalytics.com"
+    },
     "SimpleHTTP": {
       "cats": [
         22

--- a/src/icons/SimpleAnalytics.svg
+++ b/src/icons/SimpleAnalytics.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.0" viewBox="0 0 100 100"><path fill="#FF4F64" d="M20 53h10v30H20zm24-18h10v48H44zm24-17h10v65H68z"/></svg>


### PR DESCRIPTION
### Site examples:
1. [AppZapper](https://appzapper.com/)
1. [Pieter Levels](https://levels.io/)
1. [ReviewBot Blog](blog.reviewbot.io)
1. [Graphite Docs](https://www.graphitedocs.com/)
1. [MAKE: Bootstrapper's Handbook](https://makebook.io)
1. [Byrdseed](http://www.byrdseed.com)
1. [Work and Whistle](https://workandwhistle.co)
1. [Maker Weekly](https://makerweekly.co)
1. [Fable](https://www.fable.co)
1. [Curiosities and Puzzlements](https://puzzlements.co)