### PR TITLE
Update WP Engine detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11389,7 +11389,9 @@
         62
       ],
       "headers": {
-        "wpe-backend": ""
+        "wpe-backend": "",
+        "X-Pass-Why": "",
+        "X-WPE-Loopback-Upstream-Addr": ""
       },
       "icon": "wpengine.svg",
       "implies": "WordPress",


### PR DESCRIPTION
- Added new headers that can be detected

There are a few new WP Engine specific headers that are exposed to use for additional detection.

`x-pass-why` is specific to a [cache control plugin](https://wordpress.org/plugins/wpe-advanced-cache-options/) used only for WP Engine, in addition to this loopback header.