### PR TITLE
Better Click Funnels Detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1481,8 +1481,8 @@
       "cats": [
         32
       ],
+      "html": "<meta property=\"cf:app_domain\" content=\"app.clickfunnels.com\"",
       "env": "Clickfunnels",
-      "script": "clickfunnels\\.com",
       "icon": "ClickFunnels.png",
       "website": "https://www.clickfunnels.com"
     },

--- a/src/drivers/webextension/manifest.json
+++ b/src/drivers/webextension/manifest.json
@@ -74,11 +74,5 @@
     "http://*/*",
     "https://*/*"
   ],
-  "content_security_policy": "script-src 'self'; object-src 'self'",
-  "applications": {
-    "gecko": {
-      "id": "wappalyzer@crunchlabz.com",
-      "strict_min_version": "60.0"
-    }
-  }
+  "content_security_policy": "script-src 'self'; object-src 'self'"
 }


### PR DESCRIPTION
Hello,
I noticed that, on some websites, the ClickFunnels detection wasn't working.
Example :
- https://go.iag-media.com/kaizencure

It's because of the fact that their scripts' src are not using clickfunnels domain but their one, therefore the detection of clickfunnels using those scripts isn't working.

Here is another fix that should work on every clickfunnels website.