### PR TITLE
Added support for the new Intershop progressive web app

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5039,6 +5039,7 @@
         6
       ],
       "icon": "Intershop.png",
+      "html": "<ish-root",
       "script": "(?:is-bin|INTERSHOP)",
       "website": "http://intershop.com"
     },


### PR DESCRIPTION
I am Enterprise Architect at Intershop Communications AG. We provide a digital commerce platform:
https://www.wappalyzer.com/technologies/intershop

We have recently updated our product and use now a progressive web app based on Angular.

However, with this technological change, Intershop is not recognized by Wappalyzer anymore.

Therefore I added the detection of the Intershop PWA based on the  “&lt;ish-root&gt;” element. ISH is the abbreviation for Intershop, the Xetra Stock symbol is ISH2.

Here an example of an Intershop client already using the Intershop PWA:
https://shop.zeiss.de/

Thanks
Nils