### PR TITLE
Improve Carbon Ads script pattern

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1763,7 +1763,7 @@
       "js": {
         "_carbonads": ""
       },
-      "script": "//(?:engine|srv)\\.carbonads\\.com\\/",
+      "script": "^(?:https?:)?\\/\\/(?:[^\\/]+\\.)*carbonads\\.com\\/",
       "website": "http://carbonads.net"
     },
     "Cargo": {


### PR DESCRIPTION
Carbon Ads now uses *cdn.carbonads.com*, which isn't matched yet. This pattern will match all scripts loaded from carbonads.com and any subdomains. HTTP, HTTPS and protocol-relative URLs will match.

Not overly broad because the informational website is at carbonads**.net**