### PR TITLE
Improve webtrekk detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11580,7 +11580,15 @@
       ],
       "icon": "Webtrekk.png",
       "js": {
-        "webtrekk": ""
+        "webtrekk": "",
+        "webtrekkConfig": "",
+        "webtrekkHeatmapObjects": "",
+        "webtrekkLinktrackObjects": "",
+        "webtrekkUnloadObjects": "",
+        "webtrekkV3": "",
+        "WebtrekkV3": "",
+        "wt_tt": "",
+        "wt_ttv2": ""
       },
       "website": "http://www.webtrekk.com"
     },


### PR DESCRIPTION
The variable `webtrekk` is only present on a few websites, it seems.
Adding a bunch of other Webtrekk variables to improve detection