### PR TITLE
fix example in npm readme.md

### DIFF
--- a/src/drivers/npm/README.md
+++ b/src/drivers/npm/README.md
@@ -66,7 +66,7 @@ const options = {
 const wappalyzer = new Wappalyzer(url, options);
 
 // Optional: set the browser to use
-// wappalyzer.browser = Wappalyzer.browsers.zombie;
+// wappalyzer.Browser = Wappalyzer.browsers.zombie;
 
 // Optional: capture log output
 // wappalyzer.on('log', params => {


### PR DESCRIPTION
capitalization fix -

while class Wappalyzer defines “this.browser = ZombieBrowser;” its constructor returns instance of Driver, that defines “this.Browser = Browser;”