### PR TITLE
Fix HTML pattern for Vue.js

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11631,7 +11631,7 @@
       "cats": [
         12
       ],
-      "html": "<[^>]+data-v(?:ue)-",
+      "html": "<[^>]+\\sdata-v(?:ue)?-",
       "icon": "Vue.js.png",
       "js": {
         "Vue.version": "^(.+)$\\;version:\\1"


### PR DESCRIPTION
A non-capturing group was accidentally not marked as optional

Also make it a little more strict by ensuring there is a ` ` or other whitespace before the attribute