### PR TITLE
Improve Google Web Toolkit detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -4409,7 +4409,12 @@
       "icon": "Google Web Toolkit.png",
       "implies": "Java",
       "js": {
-        "__gwt_": ""
+        "__gwt_": "",
+        "__gwt_getMetaProperty": "",
+        "__gwt_activeModules": "",
+        "__gwt_isKnownPropertyValue": "",
+        "__gwt_stylesLoaded": "",
+        "__gwtlistener": ""
       },
       "meta": {
         "gwt:property": ""


### PR DESCRIPTION
I  don't think `__gwt_` actually exists as a variable (leaving it around just to be sure). Adding some JavaScript variables that *do* exist.