### PR TITLE
Add Fastly CDN to Pantheon

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8142,7 +8142,8 @@
       "implies": [
         "PHP",
         "Nginx",
-        "MariaDB"
+        "MariaDB",
+        "Fastly"
       ],
       "icon": "pantheon.svg",
       "website": "https://pantheon.io/"


### PR DESCRIPTION
Pantheon integrates Fastly as a CDN as part of their platform, so every Pantheon site will have Fastly bundled with it.