### PR TITLE
Remove WordPress from RevSlider

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9161,7 +9161,6 @@
         "<link[^>]* href=[\\'\"][^']+revslider[/\\w-]+\\.css\\?ver=([0-9.]+)[\\'\"]\\;version:\\1"
       ],
       "icon": "revslider.png",
-      "implies": "WordPress",
       "script": "/revslider/[/\\w-]+/js",
       "website": "https://revolution.themepunch.com/"
     },


### PR DESCRIPTION
- Revolution Slider offers a non-WordPress library, so this assumption isn’t the best usage.
- There are plenty of other WP detections, so removing this should be fine.
- fixes #2362 