### PR TITLE
[TASK] Add some additional checks for TYPO3

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -10713,14 +10713,15 @@
         1
       ],
       "html": [
-        "<link[^>]+ href=\"typo3(?:conf|temp)/",
-        "<img[^>]+ src=\"typo3(?:conf|temp)/"
+        "<link[^>]+ href=\"/?typo3(?:conf|temp)/",
+        "<img[^>]+ src=\"/?typo3(?:conf|temp)/",
+        "<!--\n\tThis website is powered by TYPO3"
       ],
       "icon": "TYPO3.svg",
       "implies": "PHP",
-      "script": "^typo3(?:conf|temp)/",
+      "script": "^/?typo3(?:conf|temp)/",
       "meta": {
-        "generator": "TYPO3\\s+(?:CMS\\s+)?([\\d.]+)?(?:\\s+CMS)?\\;version:\\1"
+        "generator": "TYPO3\\s+(?:CMS\\s+)?(?:[\\d.]+)?(?:\\s+CMS)?"
       },
       "url": "/typo3/",
       "website": "https://typo3.org/"

--- a/src/drivers/npm/npm-shrinkwrap.json
+++ b/src/drivers/npm/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "wappalyzer",
-  "version": "5.8.4",
+  "version": "5.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
TYPO3 CMS is not properly recognized when the resources are loaded using absolute URIs.

In order to prevent this, an optional slash has been added to the checks for `link`, `img` and `script` tags.

Also an additional rule to check if the source code contains the famous "This website is powered by TYPO3" comment at the top.

The JavaScript function `decryptString` is used by TYPO3 CMS to decrypt encrypted `mailto:` urls in the page and is available at any time. I'm pretty confident that TYPO3 is the only CMS using this function with this name but I'll gladly be proven wrong if anybody knows something else. If that's the case, we could change the confidence to 50 or less (or remove this check completely).