### PR TITLE
Add detection patterns for Shopware 6

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -9910,6 +9910,12 @@
         6
       ],
       "html": "<title>Shopware ([\\d\\.]+) [^<]+\\;version:\\1",
+      "headers": {
+        "sw-context-token": "^[\\w]{32}$\\;version:6",
+        "sw-language-id": "^[a-fA-F0-9]{32}$\\;version:6",
+        "sw-invalidation-states": "\\;version:6",
+        "sw-version-id": "\\;version:6"
+      },
       "icon": "Shopware.png",
       "implies": [
         "PHP",
@@ -9925,7 +9931,7 @@
         "/jquery\\.shopware\\.min\\.js",
         "/engine/Shopware/"
       ],
-      "website": "http://shopware.com"
+      "website": "https://www.shopware.com"
     },
     "Signal": {
       "cats": [


### PR DESCRIPTION
A new version 6 of Shopware got released, this PR adds support for that (and updates the website link).

A demo shop: https://friendsofshopware2.shopwaredemo.store/

Sites using Shopware 6 are:
- https://www.click-six.de/
- https://www.clew.de/
