### PR TITLE
Catch Cecil version

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8119,7 +8119,7 @@
       ],
       "icon": "Cecil.png",
       "meta": {
-        "generator": "^Cecil|PHPoole$"
+        "generator": "^Cecil(?: ([0-9.]+))?$\\;version:\\1"
       },
       "website": "https://cecil.app"
     },


### PR DESCRIPTION
1. _PHPoole_ is no more supported
2. The next release of _Cecil_ will embed version number in the `generator` meta