### PR TITLE
Fix Symfony version detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -10654,7 +10654,7 @@
       "cookies": {
         "sf_redirect": ""
       },
-      "html": "(?:<div id=\"sfwdt[^\"]+\" class=\"[^\"]*sf-toolbar|<div class=\"sf-toolbar[^>]+?>[^]+<span class=\"sf-toolbar-value\">([\\d.])+)\\;version:\\1",
+      "html": "(?:<div class=\"sf-toolbar[^>]+?>[^]+<span class=\"sf-toolbar-value\">([\\d.])+|<div id=\"sfwdt[^\"]+\" class=\"[^\"]*sf-toolbar)\\;version:\\1",
       "js": {
         "Sfjs": ""
       },


### PR DESCRIPTION
Changed	`(?:<other patttern>|<pattern with version detection>)`
To	`(?:<pattern with version detection>|<other pattern>)`