### PR TITLE
Changes for Websale-Recognition

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11894,7 +11894,9 @@
         6
       ],
       "icon": "Websale.png",
-      "url": "/websale7/",
+      "cookies": {
+        "websale_ac": ""
+      },
       "website": "http://websale.de"
     },
     "Website Creator": {


### PR DESCRIPTION
Websale AG doesn’t have "websale7" in URL anymore, instead we can use cookies. Can You please update the source code?