### PR TITLE
Update Materialize implications

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -6562,7 +6562,6 @@
       ],
       "html": "<link[^>]* href=\"[^\"]*materialize(?:\\.min)?\\.css",
       "icon": "Materialize CSS.png",
-      "implies": "jQuery",
       "script": "materialize(?:\\.min)?\\.js",
       "website": "http://materializecss.com"
     },


### PR DESCRIPTION
As of version 1.0, jQuery is no longer a dependency of Materialize.