### PR TITLE
Added X-Powered-By: WP Engine header

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2,9 +2,7 @@
   "$schema": "../schema.json",
   "apps": {
     "1C-Bitrix": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "Set-Cookie": "BITRIX_",
         "X-Powered-CMS": "Bitrix Site Manager"
@@ -16,18 +14,13 @@
       "website": "http://www.1c-bitrix.ru"
     },
     "91App": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "91app.png",
       "script": "https\\:\\/\\/track\\.91app\\.io\\/track\\.js\\?",
       "website": "https://www.91app.com/"
     },
     "3dCart": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "cookies": {
         "3dvisit": ""
       },
@@ -39,9 +32,7 @@
       "website": "http://www.3dcart.com"
     },
     "A-Frame": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "html": "<a-scene[^<>]*>",
       "icon": "A-Frame.svg",
       "implies": "three.js",
@@ -52,9 +43,7 @@
       "website": "https://aframe.io"
     },
     "AD EBiS": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "html": [
         "<!-- EBiS contents tag",
         "<!--EBiS tag",
@@ -65,9 +54,7 @@
       "website": "http://www.ebis.ne.jp"
     },
     "AOLserver": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:aol:aolserver",
       "headers": {
         "Server": "AOLserver/?([\\d.]+)?\\;version:\\1"
@@ -76,9 +63,7 @@
       "website": "http://aolserver.com"
     },
     "AT Internet Analyzer": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "AT Internet.png",
       "js": {
         "ATInternet": "",
@@ -87,9 +72,7 @@
       "website": "http://atinternet.com/en"
     },
     "AT Internet XiTi": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "AT Internet.png",
       "js": {
         "xt_click": ""
@@ -98,9 +81,7 @@
       "website": "http://atinternet.com/en"
     },
     "AWStats": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "cpe": "cpe:/a:laurent_destailleur:awstats",
       "icon": "AWStats.png",
       "implies": "Perl",
@@ -110,31 +91,22 @@
       "website": "http://awstats.sourceforge.net"
     },
     "AMP": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "html": "<html[^>]* (?:amp|⚡)[^-]",
       "icon": "Accelerated-Mobile-Pages.svg",
       "website": "https://www.amp.dev"
     },
     "AMP Plugin": {
-      "cats": [
-        1,
-        5
-      ],
+      "cats": [1, 5],
       "icon": "Accelerated-Mobile-Pages.svg",
-      "implies": [
-        "WordPress"
-      ],
+      "implies": ["WordPress"],
       "meta": {
         "generator": "^AMP Plugin v(\\d+\\.\\d+.*)$\\;version:\\1"
       },
       "website": "https://amp-wp.org"
     },
     "Apollo": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Apollo.svg",
       "js": {
         "__APOLLO_CLIENT__": "",
@@ -143,9 +115,7 @@
       "website": "https://www.apollographql.com"
     },
     "Arc Publishing": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<div [^>]*id=\"pb-root\"",
       "js": {
         "Fusion.arcSite": ""
@@ -154,9 +124,7 @@
       "website": "https://www.arcpublishing.com/"
     },
     "Azure": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "azure-regionname": "",
         "azure-sitename": "",
@@ -171,9 +139,7 @@
       "website": "https://azure.microsoft.com"
     },
     "Azure CDN": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "server": "^(?:ECAcc|ECS|ECD)",
         "X-EC-Debug": ""
@@ -182,25 +148,16 @@
       "website": "https://azure.microsoft.com/en-us/services/cdn/"
     },
     "Acquia Cloud": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "X-AH-Environment": "^\\w+$"
       },
       "icon": "acquia-cloud.png",
-      "implies": [
-        "Drupal\\;confidence:95",
-        "Apache",
-        "Percona",
-        "Amazon EC2"
-      ],
+      "implies": ["Drupal\\;confidence:95", "Apache", "Percona", "Amazon EC2"],
       "website": "https://www.acquia.com/"
     },
     "Act-On": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "icon": "ActOn.png",
       "js": {
         "ActOn": ""
@@ -208,17 +165,13 @@
       "website": "http://act-on.com"
     },
     "AdInfinity": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "AdInfinity.png",
       "script": "adinfinity\\.com\\.au",
       "website": "http://adinfinity.com.au"
     },
     "AdOcean": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "AdOcean.png",
       "implies": "Gemius",
       "js": {
@@ -233,9 +186,7 @@
       "website": "https://adocean-global.com"
     },
     "AdRiver": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": "(?:<embed[^>]+(?:src=\"https?://mh\\d?\\.adriver\\.ru/|flashvars=\"[^\"]*(?:http:%3A//(?:ad|mh\\d?)\\.adriver\\.ru/|adriver_banner))|<(?:(?:iframe|img)[^>]+src|a[^>]+href)=\"https?://ad\\.adriver\\.ru/)",
       "icon": "AdRiver.png",
       "js": {
@@ -245,9 +196,7 @@
       "website": "http://adriver.ru"
     },
     "AdRoll": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "AdRoll.svg",
       "js": {
         "adroll_adv_id": "",
@@ -257,9 +206,7 @@
       "website": "http://adroll.com"
     },
     "Adcash": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Adcash.svg",
       "js": {
         "SuLoaded": "",
@@ -275,17 +222,13 @@
       "website": "http://adcash.com"
     },
     "AddShoppers": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "AddShoppers.png",
       "script": "cdn\\.shop\\.pe/widget/",
       "website": "http://www.addshoppers.com"
     },
     "AddThis": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "AddThis.svg",
       "js": {
         "addthis": ""
@@ -294,9 +237,7 @@
       "website": "http://www.addthis.com"
     },
     "AddToAny": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "AddToAny.png",
       "js": {
         "a2apage_init": ""
@@ -305,9 +246,7 @@
       "website": "http://www.addtoany.com"
     },
     "Adminer": {
-      "cats": [
-        3
-      ],
+      "cats": [3],
       "html": [
         "Adminer</a> <span class=\"version\">([\\d.]+)</span>\\;version:\\1",
         "onclick=\"bodyClick\\(event\\);\" onload=\"verifyVersion\\('([\\d.]+)'\\);\">\\;version:\\1"
@@ -317,9 +256,7 @@
       "website": "http://www.adminer.org"
     },
     "Adnegah": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "headers": {
         "X-Advertising-By": "adnegah\\.net"
       },
@@ -329,9 +266,7 @@
       "website": "https://Adnegah.net"
     },
     "Adobe ColdFusion": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cpe": "cpe:/a:adobe:coldfusion",
       "headers": {
         "Cookie": "CFTOKEN="
@@ -347,9 +282,7 @@
       "website": "http://adobe.com/products/coldfusion-family.html"
     },
     "Adobe DTM": {
-      "cats": [
-        42
-      ],
+      "cats": [42],
       "js": {
         "_satellite": ""
       },
@@ -357,9 +290,7 @@
       "website": "https://marketing.adobe.com/resources/help/en_US/dtm/c_overview.html"
     },
     "Adobe Experience Manager": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:adobe:experience_manager",
       "html": [
         "<div class=\"[^\"]*parbase",
@@ -368,17 +299,11 @@
       ],
       "icon": "Adobe Experience Manager.svg",
       "implies": "Java",
-      "script": [
-        "/etc/designs/",
-        "/etc/clientlibs/",
-        "/etc.clientlibs/"
-      ],
+      "script": ["/etc/designs/", "/etc/clientlibs/", "/etc.clientlibs/"],
       "website": "https://www.adobe.com/marketing/experience-manager.html"
     },
     "Adobe GoLive": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "cpe": "cpe:/a:adobe:golive",
       "icon": "Adobe GoLive.png",
       "meta": {
@@ -387,9 +312,7 @@
       "website": "http://www.adobe.com/products/golive"
     },
     "Adobe Muse": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "icon": "Adobe Muse.svg",
       "meta": {
         "generator": "^Muse(?:$| ?/?(\\d[\\d.]+))\\;version:\\1"
@@ -397,9 +320,7 @@
       "website": "http://muse.adobe.com"
     },
     "Adobe RoboHelp": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "cpe": "cpe:/a:adobe:robohelp",
       "icon": "Adobe RoboHelp.svg",
       "js": {
@@ -416,9 +337,7 @@
       "website": "http://adobe.com/products/robohelp.html"
     },
     "ADPLAN": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "ADPLAN.png",
       "script": [
         "^https?://[^.]+\\.adplan7\\.com/\\;version:7",
@@ -427,18 +346,14 @@
       "website": "https://www.adplan7.com/"
     },
     "Advanced Web Stats": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "html": "aws\\.src = [^<]+caphyon-analytics",
       "icon": "Advanced Web Stats.png",
       "implies": "Java",
       "website": "http://www.advancedwebstats.com"
     },
     "Advert Stream": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Advert Stream.png",
       "js": {
         "advst_is_above_the_fold": ""
@@ -447,18 +362,14 @@
       "website": "http://www.advertstream.com"
     },
     "Adverticum": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Adverticum.svg",
       "script": "(?:ad\\.)?adverticum\\.net/g3\\.js",
       "html": "<div (?:id=\"[a-zA-Z0-9_]*\" )?class=\"goAdverticum\"",
       "website": "http://adverticum.net"
     },
     "Adyen": {
-      "cats": [
-        41
-      ],
+      "cats": [41],
       "icon": "Adyen.svg",
       "js": {
         "adyen.encrypt.version": "^(.+)$\\;version:\\1"
@@ -466,9 +377,7 @@
       "website": "https://www.adyen.com"
     },
     "Adzerk": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": "<iframe [^>]*src=\"[^\"]+adzerk\\.net",
       "icon": "Adzerk.png",
       "js": {
@@ -479,23 +388,16 @@
       "website": "http://adzerk.com"
     },
     "Aegea": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "headers": {
         "X-Powered-By": "^E2 Aegea v(\\d+)$\\;version:\\1"
       },
       "icon": "Aegea.png",
-      "implies": [
-        "PHP",
-        "jQuery"
-      ],
+      "implies": ["PHP", "jQuery"],
       "website": "http://blogengine.ru"
     },
     "Afosto": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-Powered-By": "Afosto SaaS BV"
       },
@@ -503,9 +405,7 @@
       "website": "http://afosto.com"
     },
     "AfterBuy": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": [
         "<dd>This OnlineStore is brought to you by ViA-Online GmbH Afterbuy\\. Information and contribution at https://www\\.afterbuy\\.de</dd>"
       ],
@@ -514,9 +414,7 @@
       "website": "http://www.afterbuy.de"
     },
     "Ahoy": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "js": {
         "ahoy": ""
       },
@@ -528,17 +426,13 @@
       "website": "https://github.com/ankane/ahoy"
     },
     "Aircall": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "aircall.png",
       "script": "^https?://cdn\\.aircall\\.io/",
       "website": "http://aircall.io"
     },
     "Airee": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Server": "^Airee"
       },
@@ -546,19 +440,13 @@
       "website": "http://xn--80aqc2a.xn--p1ai"
     },
     "Airform": {
-      "cats": [
-        61
-      ],
-      "html": [
-        "<form[^>]+?action=\"[^\"]+airform.io"
-      ],
+      "cats": [61],
+      "html": ["<form[^>]+?action=\"[^\"]+airform.io"],
       "icon": "Airform.svg",
       "website": "https://airform.io"
     },
     "Akamai": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "X-Akamai-Transformed": ""
       },
@@ -566,9 +454,7 @@
       "website": "http://akamai.com"
     },
     "Akaunting": {
-      "cats": [
-        55
-      ],
+      "cats": [55],
       "headers": {
         "X-Akaunting": "^Free Accounting Software$"
       },
@@ -581,10 +467,7 @@
       "website": "https://akaunting.com"
     },
     "Akka HTTP": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "cpe": "cpe:/a:lightbend:akka_http",
       "headers": {
         "Server": "akka-http(?:/([\\d.]+))?\\;version:\\1"
@@ -593,9 +476,7 @@
       "website": "http://akka.io"
     },
     "Algolia Realtime Search": {
-      "cats": [
-        29
-      ],
+      "cats": [29],
       "icon": "Algolia Realtime Search.svg",
       "js": {
         "AlgoliaSearch": "",
@@ -604,9 +485,7 @@
       "website": "http://www.algolia.com"
     },
     "All in One SEO Pack": {
-      "cats": [
-        54
-      ],
+      "cats": [54],
       "cpe": "cpe:/a:semperfiwebdesign:all_in_one_seo_pack",
       "html": "<!-- All in One SEO Pack ([\\d.]+) \\;version:\\1",
       "icon": "all-in-One-SEO-Pack.png",
@@ -614,9 +493,7 @@
       "website": "https://wordpress.org/plugins/all-in-one-seo-pack/"
     },
     "Allegro RomPager": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Allegro-Software-RomPager(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -624,14 +501,9 @@
       "website": "http://allegrosoft.com/embedded-web-server-s2"
     },
     "AlloyUI": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "AlloyUI.png",
-      "implies": [
-        "Bootstrap",
-        "YUI"
-      ],
+      "implies": ["Bootstrap", "YUI"],
       "js": {
         "AUI": ""
       },
@@ -639,9 +511,7 @@
       "website": "http://www.alloyui.com"
     },
     "Amaya": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "icon": "Amaya.png",
       "meta": {
         "generator": "Amaya(?: V?([\\d.]+[a-z]))?\\;version:\\1"
@@ -649,9 +519,7 @@
       "website": "http://www.w3.org/Amaya"
     },
     "Amazon Cloudfront": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Via": "\\(CloudFront\\)$",
         "X-Amz-Cf-Id": ""
@@ -661,9 +529,7 @@
       "website": "http://aws.amazon.com/cloudfront/"
     },
     "Amazon EC2": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "\\(Amazon\\)"
       },
@@ -672,30 +538,21 @@
       "website": "http://aws.amazon.com/ec2/"
     },
     "Amazon Web Services": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "icon": "aws.svg",
       "website": "https://aws.amazon.com/"
     },
     "Amazon ECS": {
-      "cats": [
-        63
-      ],
+      "cats": [63],
       "headers": {
         "Server": "^ECS"
       },
       "icon": "aws.svg",
-      "implies": [
-        "Amazon Web Services",
-        "Docker"
-      ],
+      "implies": ["Amazon Web Services", "Docker"],
       "website": "https://aws.amazon.com/elasticloadbalancing/"
     },
     "Amazon ELB": {
-      "cats": [
-        65
-      ],
+      "cats": [65],
       "cookies": {
         "AWSELB": ""
       },
@@ -704,9 +561,7 @@
       "website": "https://aws.amazon.com/elasticloadbalancing/"
     },
     "Amazon S3": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "headers": {
         "Server": "^AmazonS3$"
       },
@@ -715,10 +570,7 @@
       "website": "http://aws.amazon.com/s3/"
     },
     "Amber": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "headers": {
         "X-Powered-By": "^Amber$"
       },
@@ -726,9 +578,7 @@
       "website": "https://amberframework.org"
     },
     "Ametys": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Ametys.png",
       "implies": "Java",
       "meta": {
@@ -738,9 +588,7 @@
       "website": "http://ametys.org"
     },
     "Amiro.CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Amiro.CMS.png",
       "implies": "PHP",
       "meta": {
@@ -749,19 +597,13 @@
       "website": "http://amirocms.com"
     },
     "Amplitude": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "amplitude.png",
-      "script": [
-        "cdn\\.amplitude\\.com"
-      ],
+      "script": ["cdn\\.amplitude\\.com"],
       "website": "https://amplitude.com/"
     },
     "Analysys Ark": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "js": {
         "AnalysysAgent": ""
       },
@@ -773,21 +615,14 @@
       "website": "https://ark.analysys.cn"
     },
     "Anetwork": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Anetwork.png",
       "script": "static-cdn\\.anetwork\\.ir/",
       "website": "https://www.anetwork.ir"
     },
     "Angular": {
-      "cats": [
-        12
-      ],
-      "excludes": [
-        "AngularDart",
-        "AngularJS"
-      ],
+      "cats": [12],
+      "excludes": ["AngularDart", "AngularJS"],
       "html": "<[^>]+ ng-version=\"([\\d.]+)\"\\;version:\\1",
       "icon": "Angular.svg",
       "js": {
@@ -797,9 +632,7 @@
       "website": "https://angular.io"
     },
     "Angular Material": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "icon": "AngularJS.svg",
       "implies": "AngularJS",
       "js": {
@@ -809,13 +642,8 @@
       "website": "https://material.angularjs.org"
     },
     "AngularDart": {
-      "cats": [
-        18
-      ],
-      "excludes": [
-        "Angular",
-        "AngularJS"
-      ],
+      "cats": [18],
+      "excludes": ["Angular", "AngularJS"],
       "icon": "AngularDart.svg",
       "implies": "Dart",
       "js": {
@@ -824,18 +652,10 @@
       "website": "https://webdev.dartlang.org/angular/"
     },
     "AngularJS": {
-      "cats": [
-        12
-      ],
-      "excludes": [
-        "Angular",
-        "AngularDart"
-      ],
+      "cats": [12],
+      "excludes": ["Angular", "AngularDart"],
       "icon": "AngularJS.svg",
-      "html": [
-        "<(?:div|html)[^>]+ng-app=",
-        "<ng-app"
-      ],
+      "html": ["<(?:div|html)[^>]+ng-app=", "<ng-app"],
       "js": {
         "angular": "",
         "angular.version.full": "^(.+)$\\;version:\\1"
@@ -848,9 +668,7 @@
       "website": "https://angularjs.org"
     },
     "Ant Design": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "html": [
         "<[^>]*class=\"ant-(?:btn|col|row|layout|breadcrumb|menu|pagination|steps|select|cascader|checkbox|calendar|form|input-number|input|mention|rate|radio|slider|switch|tree-select|time-picker|transfer|upload|avatar|badge|card|carousel|collapse|list|popover|tooltip|table|tabs|tag|timeline|tree|alert|modal|message|notification|progress|popconfirm|spin|anchor|back-top|divider|drawer)",
         "<i class=\"anticon anticon-"
@@ -862,9 +680,7 @@
       "website": "https://ant.design"
     },
     "Apache": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:apache:http_server",
       "headers": {
         "Server": "(?:Apache(?:$|/([\\d.]+)|[^/-])|(?:^|\\b)HTTPD)\\;version:\\1"
@@ -873,9 +689,7 @@
       "website": "http://apache.org"
     },
     "Apache HBase": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "cpe": "cpe:/a:apache:hbase",
       "html": "<style[^>]+static/hbase",
       "icon": "Apache HBase.png",
@@ -883,18 +697,14 @@
       "website": "http://hbase.apache.org"
     },
     "Apache Hadoop": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "cpe": "cpe:/a:apache:hadoop",
       "html": "<style[^>]+static/hadoop",
       "icon": "Apache Hadoop.svg",
       "website": "http://hadoop.apache.org"
     },
     "Apache JSPWiki": {
-      "cats": [
-        8
-      ],
+      "cats": [8],
       "cpe": "cpe:/a:apache:jspwiki",
       "html": "<html[^>]* xmlns:jspwiki=",
       "icon": "Apache JSPWiki.png",
@@ -904,9 +714,7 @@
       "website": "http://jspwiki.org"
     },
     "Apache Tomcat": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:apache:tomcat",
       "headers": {
         "Server": "^Apache-Coyote(?:/([\\d.]+))?\\;version:\\1",
@@ -917,9 +725,7 @@
       "website": "http://tomcat.apache.org"
     },
     "Apache Traffic Server": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:apache:traffic_server",
       "headers": {
         "Server": "ATS/?([\\d.]+)?\\;version:\\1"
@@ -928,9 +734,7 @@
       "website": "http://trafficserver.apache.org/"
     },
     "Apache Wicket": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cpe": "cpe:/a:apache:wicket",
       "icon": "Apache Wicket.svg",
       "implies": "Java",
@@ -940,9 +744,7 @@
       "website": "http://wicket.apache.org"
     },
     "ApexPages": {
-      "cats": [
-        51
-      ],
+      "cats": [51],
       "headers": {
         "X-Powered-By": "Salesforce\\.com ApexPages"
       },
@@ -951,44 +753,34 @@
       "website": "https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_intro.htm"
     },
     "Apigee": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "script": "/profiles/apigee",
       "html": "<script>[^>]{0,50}script src=[^>]/profiles/apigee",
       "icon": "apigee.svg",
       "website": "https://cloud.google.com/apigee/"
     },
     "Apostrophe CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<[^>]+data-apos-refreshable[^>]",
       "icon": "apostrophecms.svg",
       "implies": "Node.js",
       "website": "http://apostrophecms.org"
     },
     "AppNexus": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": "<(?:iframe|img)[^>]+adnxs\\.(?:net|com)",
       "icon": "AppNexus.svg",
       "script": "adnxs\\.(?:net|com)",
       "website": "http://appnexus.com"
     },
     "Appcues": {
-      "cats": [
-        58
-      ],
+      "cats": [58],
       "icon": "Appcues.svg",
       "script": "fast\\.appcues.com*\\.js",
       "website": "https://appcues.com"
     },
     "Arastta": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cpe": "cpe:/a:arastta:ecommerce",
       "excludes": "OpenCart",
       "headers": {
@@ -1002,20 +794,13 @@
       "website": "http://arastta.org"
     },
     "ArcGIS API for JavaScript": {
-      "cats": [
-        35
-      ],
+      "cats": [35],
       "icon": "arcgis_icon.png",
-      "script": [
-        "js\\.arcgis\\.com",
-        "basemaps\\.arcgis\\.com"
-      ],
+      "script": ["js\\.arcgis\\.com", "basemaps\\.arcgis\\.com"],
       "website": "https://developers.arcgis.com/javascript/"
     },
     "Artifactory": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "cpe": "cpe:/a:jfrog:artifactory",
       "html": [
         "<span class=\"version\">Artifactory(?: Pro)?(?: Power Pack)?(?: ([\\d.]+))?\\;version:\\1"
@@ -1024,29 +809,21 @@
       "js": {
         "ArtifactoryUpdates": ""
       },
-      "script": [
-        "wicket/resource/org\\.artifactory\\."
-      ],
+      "script": ["wicket/resource/org\\.artifactory\\."],
       "website": "http://jfrog.com/open-source/#os-arti"
     },
     "Artifactory Web Server": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:jfrog:artifactory",
       "headers": {
         "Server": "Artifactory(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "Artifactory.svg",
-      "implies": [
-        "Artifactory"
-      ],
+      "implies": ["Artifactory"],
       "website": "http://jfrog.com/open-source/#os-arti"
     },
     "ArvanCloud": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "AR-PoweredBy": "Arvan Cloud \\(arvancloud\\.com\\)"
       },
@@ -1057,11 +834,7 @@
       "website": "http://www.ArvanCloud.com"
     },
     "AsciiDoc": {
-      "cats": [
-        1,
-        20,
-        27
-      ],
+      "cats": [1, 20, 27],
       "icon": "AsciiDoc.png",
       "js": {
         "asciidoc": ""
@@ -1072,9 +845,7 @@
       "website": "http://www.methods.co.nz/asciidoc"
     },
     "Asciinema": {
-      "cats": [
-        14
-      ],
+      "cats": [14],
       "html": "<asciinema-player",
       "icon": "asciinema.png",
       "js": {
@@ -1084,9 +855,7 @@
       "website": "https://asciinema.org/"
     },
     "Atlassian Bitbucket": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "cpe": "cpe:/a:atlassian:bitbucket",
       "html": "<li>Atlassian Bitbucket <span title=\"[a-z0-9]+\" id=\"product-version\" data-commitid=\"[a-z0-9]+\" data-system-build-number=\"[a-z0-9]+\"> v([\\d.]+)<\\;version:\\1",
       "icon": "Atlassian Bitbucket.svg",
@@ -1100,9 +869,7 @@
       "website": "http://www.atlassian.com/software/bitbucket/overview/"
     },
     "Atlassian Confluence": {
-      "cats": [
-        8
-      ],
+      "cats": [8],
       "cpe": "cpe:/a:atlassian:confluence",
       "headers": {
         "X-Confluence-Request-Time": ""
@@ -1116,9 +883,7 @@
       "website": "http://www.atlassian.com/software/confluence/overview/team-collaboration-software"
     },
     "Atlassian FishEye": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "cookies": {
         "FESESSIONID": ""
       },
@@ -1128,9 +893,7 @@
       "website": "http://www.atlassian.com/software/fisheye/overview/"
     },
     "Atlassian Jira": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "cpe": "cpe:/a:atlassian:jira",
       "html": "Powered by\\s+<a href=[^>]+atlassian\\.com/(?:software/jira|jira-bug-tracking/)[^>]+>Atlassian\\s+JIRA(?:[^v]*v(?:ersion: )?(\\d+\\.\\d+(?:\\.\\d+)?))?\\;version:\\1",
       "icon": "Atlassian Jira.svg",
@@ -1145,10 +908,7 @@
       "website": "http://www.atlassian.com/software/jira/overview/"
     },
     "Atlassian Jira Issue Collector": {
-      "cats": [
-        13,
-        47
-      ],
+      "cats": [13, 47],
       "icon": "Atlassian Jira.svg",
       "script": [
         "jira-issue-collector-plugin",
@@ -1157,24 +917,18 @@
       "website": "http://www.atlassian.com/software/jira/overview/"
     },
     "Aurelia": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "html": [
         "<[^>]+aurelia-app=[^>]",
         "<[^>]+data-main=[^>]aurelia-bootstrapper",
         "<[^>]+au-target-id=[^>]\\d"
       ],
       "icon": "Aurelia.svg",
-      "script": [
-        "aurelia(?:\\.min)?\\.js"
-      ],
+      "script": ["aurelia(?:\\.min)?\\.js"],
       "website": "http://aurelia.io"
     },
     "Avangate": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<link[^>]* href=\"^https?://edge\\.avangate\\.net/",
       "icon": "Avangate.svg",
       "js": {
@@ -1185,17 +939,13 @@
       "website": "http://avangate.com"
     },
     "Avasize": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Avasize.png",
       "script": "^https?://cdn\\.avasize\\.com/",
       "website": "https://www.avasize.com"
     },
     "Awesomplete": {
-      "cats": [
-        29
-      ],
+      "cats": [29],
       "html": "<link[^>]+href=\"[^>]*awesomplete(?:\\.min)?\\.css",
       "js": {
         "awesomplete": ""
@@ -1204,17 +954,13 @@
       "website": "https://leaverou.github.io/awesomplete/"
     },
     "BEM": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "html": "<[^>]+data-bem",
       "icon": "BEM.png",
       "website": "http://en.bem.info"
     },
     "BIGACE": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "(?:Powered by <a href=\"[^>]+BIGACE|<!--\\s+Site is running BIGACE)",
       "icon": "BIGACE.png",
       "implies": "PHP",
@@ -1224,9 +970,7 @@
       "website": "http://bigace.de"
     },
     "Babel": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "Babel.svg",
       "js": {
         "_babelPolyfill": ""
@@ -1234,10 +978,7 @@
       "website": "https://babeljs.io"
     },
     "Bablic": {
-      "cats": [
-        3,
-        9
-      ],
+      "cats": [3, 9],
       "icon": "bablic.png",
       "js": {
         "bablic": ""
@@ -1245,9 +986,7 @@
       "website": "https://www.bablic.com/"
     },
     "Backbone.js": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Backbone.js.png",
       "implies": "Underscore.js",
       "js": {
@@ -1258,9 +997,7 @@
       "website": "http://backbonejs.org"
     },
     "Backdrop": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Backdrop-Cache": "",
         "X-Generator": "^Backdrop CMS(?:\\s([\\d.]+))?\\;version:\\1"
@@ -1277,9 +1014,7 @@
       "website": "https://backdropcms.org"
     },
     "Backpack": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "cookies": {
         "backpack_session=": ""
       },
@@ -1288,9 +1023,7 @@
       "website": "https://backpackforlaravel.com"
     },
     "Backtory": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "X-Powered-By": "Backtory"
       },
@@ -1298,10 +1031,7 @@
       "website": "https://backtory.com"
     },
     "Banshee": {
-      "cats": [
-        1,
-        18
-      ],
+      "cats": [1, 18],
       "html": "Built upon the <a href=\"[^>]+banshee-php\\.org/\">[a-z]+</a>(?:v([\\d.]+))?\\;version:\\1",
       "icon": "Banshee.png",
       "implies": "PHP",
@@ -1311,9 +1041,7 @@
       "website": "http://www.banshee-php.org"
     },
     "BaseHTTP": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "BaseHTTP\\/?([\\d\\.]+)?\\;version:\\1"
       },
@@ -1322,9 +1050,7 @@
       "website": "http://docs.python.org/2/library/basehttpserver.html"
     },
     "BigBangShop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-SERVER": "BIGBANGSHOP"
       },
@@ -1332,20 +1058,13 @@
       "website": "https://www.bigbangshop.com.br"
     },
     "BigDump": {
-      "cats": [
-        3
-      ],
+      "cats": [3],
       "html": "<!-- <h1>BigDump: Staggered MySQL Dump Importer ver\\. ([\\d.b]+)\\;version:\\1",
-      "implies": [
-        "MySQL",
-        "PHP"
-      ],
+      "implies": ["MySQL", "PHP"],
       "website": "http://www.ozerov.de/bigdump.php"
     },
     "Bigcommerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<link href=[^>]+cdn\\d+\\.bigcommerce\\.com/",
       "icon": "Bigcommerce.png",
       "script": "cdn\\d+\\.bigcommerce\\.com/",
@@ -1353,9 +1072,7 @@
       "website": "http://www.bigcommerce.com"
     },
     "Bigware": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "bigWAdminID": "",
         "bigwareCsid": ""
@@ -1368,9 +1085,7 @@
       "website": "http://bigware.de"
     },
     "BittAds": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "BittAds.png",
       "js": {
         "bitt": ""
@@ -1379,9 +1094,7 @@
       "website": "http://bittads.com"
     },
     "Bizweb": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "bizweb.png",
       "js": {
         "Bizweb": ""
@@ -1389,10 +1102,7 @@
       "website": "https://www.bizweb.vn"
     },
     "Blade": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "headers": {
         "X-Powered-By": "blade-([\\w.]+)?\\;version:\\1"
       },
@@ -1401,9 +1111,7 @@
       "website": "https://lets-blade.com"
     },
     "Blazor": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "icon": "Blazor.png",
       "website": "https://dotnet.microsoft.com/apps/aspnet/web-apps/blazor",
       "implies": "Microsoft ASP.NET",
@@ -1414,9 +1122,7 @@
       ]
     },
     "Blesta": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "blesta_sid": ""
       },
@@ -1424,17 +1130,13 @@
       "website": "http://www.blesta.com"
     },
     "Blip.tv": {
-      "cats": [
-        14
-      ],
+      "cats": [14],
       "html": "<(?:param|embed|iframe)[^>]+blip\\.tv/play",
       "icon": "Blip.tv.png",
       "website": "http://blip.tv"
     },
     "Blogger": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "icon": "Blogger.png",
       "implies": "Python",
       "meta": {
@@ -1444,9 +1146,7 @@
       "website": "http://www.blogger.com"
     },
     "Bluefish": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "icon": "Bluefish.png",
       "meta": {
         "generator": "Bluefish(?:\\s([\\d.]+))?\\;version:\\1"
@@ -1454,9 +1154,7 @@
       "website": "http://sourceforge.net/projects/bluefish"
     },
     "Boa": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:boa:boa",
       "headers": {
         "Server": "Boa\\/?([\\d\\.a-z]+)?\\;version:\\1"
@@ -1464,26 +1162,19 @@
       "website": "http://www.boa.org"
     },
     "Boba.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "implies": "Google Analytics",
       "script": "boba(?:\\.min)?\\.js",
       "website": "http://boba.space150.com"
     },
     "Bold Chat": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "BoldChat.png",
       "script": "^https?://vmss\\.boldchat\\.com/aid/\\d{18}/bc\\.vms4/vms\\.js",
       "website": "https://www.boldchat.com/"
     },
     "BoldGrid": {
-      "cats": [
-        1,
-        11
-      ],
+      "cats": [1, 11],
       "html": [
         "<link rel=[\"']stylesheet[\"'] [^>]+boldgrid",
         "<link rel=[\"']stylesheet[\"'] [^>]+post-and-page-builder",
@@ -1494,9 +1185,7 @@
       "website": "https://boldgrid.com"
     },
     "Bolt": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:bolt:bolt",
       "icon": "Bolt.png",
       "implies": "PHP",
@@ -1506,9 +1195,7 @@
       "website": "http://bolt.cm"
     },
     "BOOM": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "implies": "WordPress",
       "meta": {
         "generator": "^boom site builder$"
@@ -1520,9 +1207,7 @@
       "website": "http://manaandisheh.com"
     },
     "Bonfire": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "bf_session": ""
       },
@@ -1532,9 +1217,7 @@
       "website": "http://cibonfire.com"
     },
     "Bootstrap": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "cpe": "cpe:/a:getbootstrap:bootstrap",
       "html": [
         "<style>/\\*!\\* Bootstrap v(\\d\\.\\d\\.\\d)\\;version:\\1",
@@ -1555,31 +1238,22 @@
       "website": "https://getbootstrap.com"
     },
     "Bootstrap Table": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "html": "<link[^>]+href=\"[^>]*bootstrap-table(?:\\.min)?\\.css",
       "icon": "Bootstrap Table.svg",
-      "implies": [
-        "Bootstrap",
-        "jQuery"
-      ],
+      "implies": ["Bootstrap", "jQuery"],
       "script": "bootstrap-table(?:\\.min)?\\.js",
       "website": "http://bootstrap-table.wenzhixin.net.cn/"
     },
     "ClickFunnels": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "html": "<meta property=\"cf:app_domain\" content=\"app.clickfunnels.com\"",
       "env": "Clickfunnels",
       "icon": "ClickFunnels.png",
       "website": "https://www.clickfunnels.com"
     },
     "Bounce Exchange": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "script": "^https?://tag\\.bounceexchange\\.com/",
       "icon": "Bounce Exchange.svg",
       "js": {
@@ -1588,9 +1262,7 @@
       "website": "http://www.bounceexchange.com"
     },
     "Braintree": {
-      "cats": [
-        41
-      ],
+      "cats": [41],
       "icon": "Braintree.svg",
       "js": {
         "Braintree": "",
@@ -1599,9 +1271,7 @@
       "website": "https://www.braintreepayments.com"
     },
     "Brightspot": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "^Brightspot$"
       },
@@ -1610,9 +1280,7 @@
       "website": "https://www.brightspot.com"
     },
     "BrowserCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "BrowserCMS.png",
       "implies": "Ruby",
       "meta": {
@@ -1621,10 +1289,7 @@
       "website": "http://browsercms.org"
     },
     "Bubble": {
-      "cats": [
-        1,
-        18
-      ],
+      "cats": [1, 18],
       "icon": "bubble.png",
       "implies": "Node.js",
       "headers": {
@@ -1641,9 +1306,7 @@
       "website": "http://bubble.is"
     },
     "BugSnag": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "BugSnag.png",
       "js": {
         "Bugsnag": "",
@@ -1654,9 +1317,7 @@
       "website": "http://bugsnag.com"
     },
     "Bugzilla": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "cpe": "cpe:/a:mozilla:bugzilla",
       "html": [
         "href=\"enter_bug\\.cgi\">",
@@ -1678,38 +1339,27 @@
       "website": "http://www.bugzilla.org"
     },
     "Bulma": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": "<link[^>]+?href=\"[^\"]+bulma(?:\\.min)?\\.css",
       "icon": "Bulma.png",
       "website": "http://bulma.io"
     },
     "Burning Board": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "html": "<a href=\"[^>]+woltlab\\.com[^<]+<strong>Burning Board",
       "icon": "Burning Board.png",
-      "implies": [
-        "PHP",
-        "Woltlab Community Framework"
-      ],
+      "implies": ["PHP", "Woltlab Community Framework"],
       "website": "http://www.woltlab.com"
     },
     "Business Catalyst": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<!-- BC_OBNW -->",
       "icon": "Business Catalyst.png",
       "script": "CatalystScripts",
       "website": "http://businesscatalyst.com"
     },
     "BuySellAds": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "script": "^https?://s\\d\\.buysellads\\.com/",
       "icon": "BuySellAds.png",
       "js": {
@@ -1721,9 +1371,7 @@
       "website": "http://buysellads.com"
     },
     "CDN77": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Server": "^CDN77-Turbo$"
       },
@@ -1731,16 +1379,12 @@
       "website": "https://www.cdn77.com"
     },
     "CFML": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "icon": "CFML.png",
       "website": "http://adobe.com/products/coldfusion-family.html"
     },
     "CKEditor": {
-      "cats": [
-        24
-      ],
+      "cats": [24],
       "cpe": "cpe:/a:ckeditor:ckeditor",
       "icon": "CKEditor.png",
       "js": {
@@ -1751,9 +1395,7 @@
       "website": "http://ckeditor.com"
     },
     "CMS Made Simple": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "CMSSESSID": ""
       },
@@ -1766,9 +1408,7 @@
       "website": "http://cmsmadesimple.org"
     },
     "CMSimple": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:cmsimple:cmsimple",
       "implies": "PHP",
       "meta": {
@@ -1777,9 +1417,7 @@
       "website": "http://www.cmsimple.org/en"
     },
     "CPG Dragonfly": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "^Dragonfly CMS"
       },
@@ -1791,9 +1429,7 @@
       "website": "http://dragonflycms.org"
     },
     "CS Cart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": [
         "&nbsp;Powered by (?:<a href=[^>]+cs-cart\\.com|CS-Cart)",
         "\\.cm-noscript[^>]+</style>"
@@ -1806,9 +1442,7 @@
       "website": "http://www.cs-cart.com"
     },
     "CacheFly": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Server": "^CFS ",
         "X-CF1": "",
@@ -1818,9 +1452,7 @@
       "website": "http://www.cachefly.com"
     },
     "Caddy": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "^Caddy$"
       },
@@ -1829,9 +1461,7 @@
       "website": "http://caddyserver.com"
     },
     "CakePHP": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "cakephp": ""
       },
@@ -1844,10 +1474,7 @@
       "website": "http://cakephp.org"
     },
     "Captch Me": {
-      "cats": [
-        16,
-        36
-      ],
+      "cats": [16, 36],
       "icon": "Captch Me.svg",
       "js": {
         "Captchme": ""
@@ -1856,9 +1483,7 @@
       "website": "http://captchme.com"
     },
     "Carbon Ads": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": "<[a-z]+ [^>]*id=\"carbonads-container\"",
       "icon": "Carbon Ads.png",
       "js": {
@@ -1868,9 +1493,7 @@
       "website": "http://carbonads.net"
     },
     "Cargo": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<link [^>]+Cargo feed",
       "icon": "Cargo.png",
       "implies": "PHP",
@@ -1881,10 +1504,7 @@
       "website": "http://cargocollective.com"
     },
     "Catberry.js": {
-      "cats": [
-        12,
-        18
-      ],
+      "cats": [12, 18],
       "headers": {
         "X-Powered-By": "Catberry"
       },
@@ -1897,9 +1517,7 @@
       "website": "http://catberry.org"
     },
     "CentOS": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "cpe": "cpe:/o:centos:centos",
       "headers": {
         "Server": "CentOS",
@@ -1909,23 +1527,16 @@
       "website": "http://centos.org"
     },
     "Chameleon": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Chameleon.png",
-      "implies": [
-        "Apache",
-        "PHP"
-      ],
+      "implies": ["Apache", "PHP"],
       "meta": {
         "generator": "chameleon-cms"
       },
       "website": "http://chameleon-system.de"
     },
     "Chamilo": {
-      "cats": [
-        21
-      ],
+      "cats": [21],
       "cpe": "cpe:/a:chamilo:chamilo_lms",
       "headers": {
         "X-Powered-By": "Chamilo ([\\d.]+)\\;version:\\1"
@@ -1939,9 +1550,7 @@
       "website": "http://www.chamilo.org"
     },
     "Chart.js": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "Chart.js.svg",
       "js": {
         "Chart": "\\;confidence:50",
@@ -1957,9 +1566,7 @@
       "website": "https://www.chartjs.org"
     },
     "Chartbeat": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Chartbeat.png",
       "js": {
         "_sf_async_config": "",
@@ -1969,9 +1576,7 @@
       "website": "http://chartbeat.com"
     },
     "Cherokee": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:cherokee-project:cherokee",
       "headers": {
         "Server": "^Cherokee(?:/([\\d.]+))?\\;version:\\1"
@@ -1980,10 +1585,7 @@
       "website": "http://www.cherokee-project.com"
     },
     "CherryPy": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "cpe": "cpe:/a:cherrypy:cherrypy",
       "headers": {
         "Server": "CherryPy\\/?([\\d\\.]+)?\\;version:\\1"
@@ -1993,9 +1595,7 @@
       "website": "http://www.cherrypy.org"
     },
     "Chevereto": {
-      "cats": [
-        7
-      ],
+      "cats": [7],
       "meta": {
         "generator": "^Chevereto ?([0-9.]+)?$\\;version:\\1"
       },
@@ -2006,9 +1606,7 @@
       "website": "https://chevereto.com/"
     },
     "Chitika": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Chitika.png",
       "js": {
         "ch_client": "",
@@ -2018,37 +1616,26 @@
       "website": "http://chitika.com"
     },
     "Chorus": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Chorus.png",
       "html": "<meta data-chorus-version=",
       "website": "https://getchorus.voxmedia.com/"
     },
     "Ckan": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "Access-Control-Allow-Headers": "X-CKAN-API-KEY",
         "Link": "<http://ckan\\.org/>; rel=shortlink"
       },
       "icon": "Ckan.png",
-      "implies": [
-        "Python",
-        "Solr",
-        "Java",
-        "PostgreSQL"
-      ],
+      "implies": ["Python", "Solr", "Java", "PostgreSQL"],
       "meta": {
         "generator": "^ckan ?([0-9.]+)$\\;version:\\1"
       },
       "website": "http://ckan.org/"
     },
     "Clarity": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": [
         "<clr-main-container",
         "<link [^>]*href=\"[^\"]*clr-ui(?:\\.min)?\\.css"
@@ -2058,15 +1645,11 @@
       },
       "script": "clr-angular(?:\\.umd)?(?:\\.min)?\\.js",
       "icon": "clarity.svg",
-      "implies": [
-        "Angular"
-      ],
+      "implies": ["Angular"],
       "website": "https://clarity.design/"
     },
     "ClickHeat": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "ClickHeat.png",
       "implies": "PHP",
       "js": {
@@ -2076,9 +1659,7 @@
       "website": "http://www.labsmedia.com/clickheat/index.html"
     },
     "ClickTale": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "ClickTale.png",
       "js": {
         "clickTaleStartEventSignal": ""
@@ -2086,9 +1667,7 @@
       "website": "http://www.clicktale.com"
     },
     "Clicky": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Clicky.png",
       "js": {
         "clicky": ""
@@ -2097,25 +1676,19 @@
       "website": "http://getclicky.com"
     },
     "Clientexec": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "clientexec\\.[^>]*\\s?=\\s?[^>]*;",
       "icon": "Clientexec.png",
       "website": "http://www.clientexec.com"
     },
     "Clipboard.js": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "Clipboard.js.svg",
       "script": "clipboard(?:-([\\d.]+))?(?:\\.min)?\\.js\\;version:\\1",
       "website": "https://clipboardjs.com/"
     },
     "CloudCart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "cloudcart.svg",
       "meta": {
         "author": "^CloudCart LLC$"
@@ -2124,9 +1697,7 @@
       "website": "http://cloudcart.com"
     },
     "CloudFlare": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Server": "^cloudflare$",
         "cf-cache-status": "",
@@ -2142,9 +1713,7 @@
       "website": "http://www.cloudflare.com"
     },
     "Cloudcoins": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "js": {
         "CLOUDCOINS": ""
       },
@@ -2152,9 +1721,7 @@
       "website": "https://cloudcoins.co"
     },
     "Cloudera": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "headers": {
         "Server": "cloudera"
       },
@@ -2162,9 +1729,7 @@
       "website": "http://www.cloudera.com"
     },
     "Coaster CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:web-feet:coaster_cms",
       "icon": "coaster-cms.png",
       "implies": "Laravel",
@@ -2174,9 +1739,7 @@
       "website": "https://www.coastercms.org"
     },
     "CodeIgniter": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "ci_csrf_token": "^(.+)$\\;version:\\1?2+:",
         "ci_session": "",
@@ -2190,9 +1753,7 @@
       "website": "http://codeigniter.com"
     },
     "CodeMirror": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "CodeMirror.png",
       "js": {
         "CodeMirror": "",
@@ -2201,9 +1762,7 @@
       "website": "http://codemirror.net"
     },
     "CoinHive": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "icon": "CoinHive.svg",
       "js": {
         "CoinHive": ""
@@ -2216,27 +1775,20 @@
       "website": "https://coinhive.com"
     },
     "CoinHive Captcha": {
-      "cats": [
-        16,
-        56
-      ],
+      "cats": [16, 56],
       "html": "(?:<div[^>]+class=\"coinhive-captcha[^>]+data-key|<div[^>]+data-key[^>]+class=\"coinhive-captcha)",
       "icon": "CoinHive.svg",
       "script": "https?://authedmine\\.com/(?:lib/captcha|captcha)",
       "website": "https://coinhive.com"
     },
     "Coinhave": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "icon": "coinhave.png",
       "script": "https?://coin-have\\.com/c/[0-9a-zA-Z]{4}\\.js",
       "website": "https://coin-have.com/"
     },
     "Coinimp": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "icon": "coinimp.png",
       "js": {
         "Client.Anonymous": "\\;confidence:50"
@@ -2245,9 +1797,7 @@
       "website": "https://www.coinimp.com"
     },
     "Coinlab": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "icon": "coinlab.png",
       "js": {
         "Coinlab": ""
@@ -2256,9 +1806,7 @@
       "website": "https://coinlab.biz/en"
     },
     "ColorMeShop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "colormeshop.png",
       "js": {
         "Colorme": ""
@@ -2266,9 +1814,7 @@
       "website": "https://shop-pro.jp"
     },
     "Comandia": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<link[^>]+=['\"]//cdn\\.mycomandia\\.com",
       "icon": "Comandia.svg",
       "js": {
@@ -2277,17 +1823,13 @@
       "website": "http://comandia.com"
     },
     "Combeenation": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<iframe[^>]+src=\"[^>]+portal\\.combeenation\\.com",
       "icon": "Combeenation.png",
       "website": "https://www.combeenation.com"
     },
     "Commerce Server": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cpe": "cpe:/a:microsoft:commerce_server",
       "headers": {
         "COMMERCE-SERVER-SOFTWARE": ""
@@ -2297,9 +1839,7 @@
       "website": "http://commerceserver.net"
     },
     "CompaqHTTPServer": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:hp:compaqhttpserver",
       "headers": {
         "Server": "CompaqHTTPServer\\/?([\\d\\.]+)?\\;version:\\1"
@@ -2308,9 +1848,7 @@
       "website": "http://www.hp.com"
     },
     "Concrete5": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:concrete5:concrete5",
       "icon": "Concrete5.png",
       "implies": "PHP",
@@ -2327,9 +1865,7 @@
       "website": "https://concrete5.org"
     },
     "Connect": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Powered-By": "^Connect$"
       },
@@ -2338,9 +1874,7 @@
       "website": "http://www.senchalabs.org/connect"
     },
     "Contao": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:contao:contao_cms",
       "html": [
         "<!--[^>]+powered by (?:TYPOlight|Contao)[^>]*-->",
@@ -2354,9 +1888,7 @@
       "website": "http://contao.org"
     },
     "Contenido": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:contenido:contendio",
       "icon": "Contenido.png",
       "implies": "PHP",
@@ -2366,24 +1898,16 @@
       "website": "http://contenido.org/en"
     },
     "Contensis": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Contensis.png",
-      "implies": [
-        "Java",
-        "CFML"
-      ],
+      "implies": ["Java", "CFML"],
       "meta": {
         "generator": "Contensis CMS Version ([\\d.]+)\\;version:\\1"
       },
       "website": "https://zengenti.com/en-gb/products/contensis"
     },
     "ContentBox": {
-      "cats": [
-        1,
-        11
-      ],
+      "cats": [1, 11],
       "icon": "ContentBox.png",
       "implies": "Adobe ColdFusion",
       "meta": {
@@ -2392,25 +1916,19 @@
       "website": "http://www.gocontentbox.org"
     },
     "Contentful": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<[^>]+(?:https?:)?//(?:assets|downloads|images|videos)\\.(?:ct?fassets\\.net|contentful\\.com)",
       "icon": "Contentful.svg",
       "website": "http://www.contentful.com"
     },
     "ConversionLab": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "ConversionLab.png",
       "script": "conversionlab\\.trackset\\.com/track/tsend\\.js",
       "website": "http://www.trackset.it/conversionlab"
     },
     "Coppermine": {
-      "cats": [
-        7
-      ],
+      "cats": [7],
       "cpe": "cpe:/a:coppermine-gallery:coppermine_photo_gallery",
       "html": "<!--Coppermine Photo Gallery ([\\d.]+)\\;version:\\1",
       "icon": "Coppermine.png",
@@ -2418,18 +1936,14 @@
       "website": "http://coppermine-gallery.net"
     },
     "Cosmoshop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cpe": "cpe:/a:cosmoshop:cosmoshop",
       "icon": "Cosmoshop.png",
       "script": "cosmoshop_functions\\.js",
       "website": "http://cosmoshop.de"
     },
     "Cotonti": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:cotonti:cotonti_siena",
       "icon": "Cotonti.png",
       "implies": "PHP",
@@ -2439,9 +1953,7 @@
       "website": "http://www.cotonti.com"
     },
     "CouchDB": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:apache:couchdb",
       "headers": {
         "Server": "CouchDB/([\\d.]+)\\;version:\\1"
@@ -2450,9 +1962,7 @@
       "website": "http://couchdb.apache.org"
     },
     "Countly": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Countly.png",
       "js": {
         "Countly": ""
@@ -2460,9 +1970,7 @@
       "website": "https://count.ly"
     },
     "Cowboy": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "^Cowboy$"
       },
@@ -2471,9 +1979,7 @@
       "website": "http://ninenines.eu"
     },
     "CppCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "^CppCMS/([\\d.]+)$\\;version:\\1"
       },
@@ -2482,9 +1988,7 @@
       "website": "http://cppcms.com"
     },
     "Craft CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "CraftSessionId": ""
       },
@@ -2497,9 +2001,7 @@
       "website": "https://craftcms.com"
     },
     "Craft Commerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-Powered-By": "\\bCraft Commerce\\b"
       },
@@ -2508,9 +2010,7 @@
       "website": "https://craftcommerce.com"
     },
     "Crazy Egg": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Crazy Egg.png",
       "js": {
         "CE2": ""
@@ -2519,9 +2019,7 @@
       "website": "http://crazyegg.com"
     },
     "Criteo": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Criteo.svg",
       "js": {
         "Criteo": "",
@@ -2535,9 +2033,7 @@
       "website": "http://criteo.com"
     },
     "Cross Pixel": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Cross Pixel.png",
       "js": {
         "cp_C4w1ldN2d9PmVrkN": ""
@@ -2546,9 +2042,7 @@
       "website": "http://datadesk.crsspxl.com"
     },
     "CrossBox": {
-      "cats": [
-        30
-      ],
+      "cats": [30],
       "icon": "CrossBox.png",
       "headers": {
         "server": "CBX-WS"
@@ -2556,9 +2050,7 @@
       "website": "https://crossbox.io"
     },
     "Crypto-Loot": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "icon": "Crypto-Loot.png",
       "js": {
         "CRLT.CONFIG.ASMJS_NAME": "",
@@ -2573,9 +2065,7 @@
       "website": "https://crypto-loot.com/"
     },
     "CubeCart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cpe": "cpe:/a:cubecart:cubecart",
       "html": "(?:Powered by <a href=[^>]+cubecart\\.com|<p[^>]+>Powered by CubeCart)",
       "icon": "CubeCart.png",
@@ -2586,9 +2076,7 @@
       "website": "http://www.cubecart.com"
     },
     "Cufon": {
-      "cats": [
-        17
-      ],
+      "cats": [17],
       "icon": "Cufon.png",
       "js": {
         "Cufon": ""
@@ -2597,9 +2085,7 @@
       "website": "http://cufon.shoqolate.com"
     },
     "D3": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "cpe": "cpe:/a:d3.js_project:d3.js",
       "icon": "D3.png",
       "js": {
@@ -2609,17 +2095,13 @@
       "website": "http://d3js.org"
     },
     "DHTMLX": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "DHTMLX.png",
       "script": "dhtmlxcommon\\.js",
       "website": "http://dhtmlx.com"
     },
     "DERAK.CLOUD": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Server": "^DERAK.CLOUD$",
         "Derak-Umbrage": ""
@@ -2635,18 +2117,14 @@
       "website": "https://derak.cloud/"
     },
     "DM Polopoly": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<(?:link [^>]*href|img [^>]*src)=\"/polopoly_fs/",
       "icon": "DM Polopoly.png",
       "implies": "Java",
       "website": "http://www.atex.com/products/dm-polopoly"
     },
     "DNN": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "DotNetNukeAnonymous": ""
       },
@@ -2656,10 +2134,7 @@
         "DNNOutputCache": "",
         "X-Compressed-By": "DotNetNuke"
       },
-      "html": [
-        "<!-- by DotNetNuke Corporation",
-        "<!-- DNN Platform"
-      ],
+      "html": ["<!-- by DotNetNuke Corporation", "<!-- DNN Platform"],
       "icon": "DNN.png",
       "implies": "Microsoft ASP.NET",
       "js": {
@@ -2669,27 +2144,18 @@
       "meta": {
         "generator": "DotNetNuke"
       },
-      "script": [
-        "/js/dnncore\\.js",
-        "/js/dnn\\.js"
-      ],
+      "script": ["/js/dnncore\\.js", "/js/dnn\\.js"],
       "website": "http://dnnsoftware.com"
     },
     "DTG": {
-      "cats": [
-        1
-      ],
-      "html": [
-        "<a[^>]+Site Powered by DTG"
-      ],
+      "cats": [1],
+      "html": ["<a[^>]+Site Powered by DTG"],
       "icon": "DTG.png",
       "implies": "Mono.net",
       "website": "https://www.dtg.nl"
     },
     "Dancer": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "Server": "Perl Dancer ([\\d.]+)\\;version:\\1",
         "X-Powered-By": "Perl Dancer ([\\d.]+)\\;version:\\1"
@@ -2699,30 +2165,20 @@
       "website": "http://perldancer.org"
     },
     "Danneo CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "CMS Danneo ([\\d.]+)\\;version:\\1"
       },
       "icon": "Danneo CMS.png",
-      "implies": [
-        "Apache",
-        "PHP"
-      ],
+      "implies": ["Apache", "PHP"],
       "meta": {
         "generator": "Danneo CMS ([\\d.]+)\\;version:\\1"
       },
       "website": "http://danneo.com"
     },
     "Dart": {
-      "cats": [
-        27
-      ],
-      "excludes": [
-        "Angular",
-        "AngularJS"
-      ],
+      "cats": [27],
+      "excludes": ["Angular", "AngularJS"],
       "html": "/(?:<script)[^>]+(?:type=\"application/dart\")/",
       "icon": "Dart.svg",
       "implies": "AngularDart",
@@ -2730,16 +2186,11 @@
         "___dart__$dart_dartObject_ZxYxX_0_": "",
         "___dart_dispatch_record_ZxYxX_0_": ""
       },
-      "script": [
-        "/(?:\\.)?(?:dart)(?:\\.js)?/",
-        "packages/browser/dart\\.js"
-      ],
+      "script": ["/(?:\\.)?(?:dart)(?:\\.js)?/", "packages/browser/dart\\.js"],
       "website": "https://www.dartlang.org"
     },
     "Darwin": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "headers": {
         "Server": "Darwin",
         "X-Powered-By": "Darwin"
@@ -2748,9 +2199,7 @@
       "website": "https://opensource.apple.com"
     },
     "Datadome": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "cookies": {
         "datadome": ""
       },
@@ -2764,15 +2213,10 @@
       "website": "https://datadome.co/"
     },
     "DataLife Engine": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:dleviet:datalife_engine",
       "icon": "DataLife Engine.png",
-      "implies": [
-        "PHP",
-        "Apache"
-      ],
+      "implies": ["PHP", "Apache"],
       "js": {
         "dle_root": ""
       },
@@ -2782,26 +2226,20 @@
       "website": "https://dle-news.ru"
     },
     "DataTables": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "DataTables.png",
       "implies": "jQuery",
       "script": "dataTables.*\\.js",
       "website": "http://datatables.net"
     },
     "DatoCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<[^>]+https://www\\.datocms-assets\\.com",
       "icon": "datocms.svg",
       "website": "https://www.datocms.com"
     },
     "Day.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Day.js.svg",
       "js": {
         "dayjs": ""
@@ -2809,9 +2247,7 @@
       "website": "https://github.com/iamkun/dayjs"
     },
     "Debian": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "cpe": "cpe:/o:debian:debian_linux",
       "headers": {
         "Server": "Debian",
@@ -2821,9 +2257,7 @@
       "website": "https://debian.org"
     },
     "decimal.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "decimal.js.png",
       "js": {
         "Decimal.ROUND_HALF_FLOOR": ""
@@ -2836,9 +2270,7 @@
       "website": "https://mikemcl.github.io/decimal.js/"
     },
     "DedeCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:dedecms:dedecms",
       "icon": "DedeCMS.png",
       "implies": "PHP",
@@ -2849,25 +2281,18 @@
       "website": "http://dedecms.com"
     },
     "DirectAdmin": {
-      "cats": [
-        9
-      ],
+      "cats": [9],
       "cpe": "cpe:/a:directadmin:directadmin",
       "headers": {
         "Server": "DirectAdmin Daemon v([\\d.]+)\\;version:\\1"
       },
       "html": "<a[^>]+>DirectAdmin</a> Web Control Panel",
       "icon": "DirectAdmin.png",
-      "implies": [
-        "PHP",
-        "Apache"
-      ],
+      "implies": ["PHP", "Apache"],
       "website": "https://www.directadmin.com"
     },
     "Discourse": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "icon": "Discourse.png",
       "implies": "Ruby on Rails",
       "js": {
@@ -2879,9 +2304,7 @@
       "website": "https://discourse.org"
     },
     "Discuz! X": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "icon": "Discuz X.png",
       "implies": "PHP",
       "js": {
@@ -2895,9 +2318,7 @@
       "website": "http://www.discuz.net"
     },
     "Disqus": {
-      "cats": [
-        15
-      ],
+      "cats": [15],
       "cpe": "cpe:/a:disqus:disqus_comment_system",
       "html": "<div[^>]+id=\"disqus_thread\"",
       "icon": "Disqus.svg",
@@ -2910,9 +2331,7 @@
       "website": "https://disqus.com"
     },
     "Django": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cpe": "cpe:/a:djangoproject:django",
       "html": "(?:powered by <a[^>]+>Django ?([\\d.]+)?<\\/a>|<input[^>]*name=[\"']csrfmiddlewaretoken[\"'][^>]*>)\\;version:\\1",
       "icon": "Django.png",
@@ -2924,22 +2343,15 @@
       "website": "https://djangoproject.com"
     },
     "Django CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Django CMS.png",
       "implies": "Django",
       "website": "https://django-cms.org"
     },
     "Docusaurus": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "icon": "docusaurus.svg",
-      "implies": [
-        "React",
-        "webpack"
-      ],
+      "implies": ["React", "webpack"],
       "js": {
         "search.indexName": ""
       },
@@ -2949,9 +2361,7 @@
       "website": "https://docusaurus.io/"
     },
     "Docker": {
-      "cats": [
-        60
-      ],
+      "cats": [60],
       "cpe": "cpe:/a:docker:engine",
       "icon": "Docker.svg",
       "implies": "Linux",
@@ -2959,9 +2369,7 @@
       "website": "https://www.docker.com/"
     },
     "Dojo": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "cpe": "cpe:/a:dojotoolkit:dojo",
       "icon": "Dojo.png",
       "js": {
@@ -2972,37 +2380,25 @@
       "website": "https://dojotoolkit.org"
     },
     "Dokeos": {
-      "cats": [
-        21
-      ],
+      "cats": [21],
       "headers": {
         "X-Powered-By": "Dokeos"
       },
       "html": "(?:Portal <a[^>]+>Dokeos|@import \"[^\"]+dokeos_blue)",
       "icon": "Dokeos.png",
-      "implies": [
-        "PHP",
-        "Xajax",
-        "jQuery",
-        "CKEditor"
-      ],
+      "implies": ["PHP", "Xajax", "jQuery", "CKEditor"],
       "meta": {
         "generator": "Dokeos"
       },
       "website": "https://dokeos.com"
     },
     "DokuWiki": {
-      "cats": [
-        8
-      ],
+      "cats": [8],
       "cookies": {
         "DokuWiki": ""
       },
       "cpe": "cpe:/a:dokuwiki:dokuwiki",
-      "html": [
-        "<div[^>]+id=\"dokuwiki__>",
-        "<a[^>]+href=\"#dokuwiki__"
-      ],
+      "html": ["<div[^>]+id=\"dokuwiki__>", "<a[^>]+href=\"#dokuwiki__"],
       "icon": "DokuWiki.png",
       "implies": "PHP",
       "meta": {
@@ -3011,9 +2407,7 @@
       "website": "https://www.dokuwiki.org"
     },
     "Dotclear": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:dotclear:dotclear",
       "headers": {
         "X-Dotclear-Static-Cache": ""
@@ -3023,9 +2417,7 @@
       "website": "http://dotclear.org"
     },
     "DoubleClick Ad Exchange (AdX)": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "DoubleClick.svg",
       "script": [
         "googlesyndication\\.com/pagead/show_ads\\.js",
@@ -3035,33 +2427,25 @@
       "website": "http://www.doubleclickbygoogle.com/solutions/digital-marketing/ad-exchange/"
     },
     "DoubleClick Campaign Manager (DCM)": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "DoubleClick.svg",
       "script": "2mdn\\.net",
       "website": "http://www.doubleclickbygoogle.com/solutions/digital-marketing/campaign-manager/"
     },
     "DoubleClick Floodlight": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "DoubleClick.svg",
       "script": "https?://fls\\.doubleclick\\.net",
       "website": "http://support.google.com/ds/answer/6029713?hl=en"
     },
     "DoubleClick for Publishers (DFP)": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "DoubleClick.svg",
       "script": "googletagservices\\.com/tag/js/gpt(?:_mobile)?\\.js",
       "website": "http://www.google.com/dfp"
     },
     "DovetailWRP": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<link[^>]* href=\"\\/DovetailWRP\\/",
       "icon": "DovetailWRP.png",
       "implies": "Microsoft ASP.NET",
@@ -3069,9 +2453,7 @@
       "website": "http://www.dovetailinternet.com"
     },
     "Doxygen": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "cpe": "cpe:/a:doxygen:doxygen",
       "html": "(?:<!-- Generated by Doxygen ([\\d.]+)|<link[^>]+doxygen\\.css)\\;version:\\1",
       "icon": "Doxygen.png",
@@ -3081,9 +2463,7 @@
       "website": "http://www.doxygen.nl/"
     },
     "DreamWeaver": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "cpe": "cpe:/a:adobe:dreamweaver",
       "html": "<!--[^>]*(?:InstanceBeginEditable|Dreamweaver([^>]+)target|DWLayoutDefaultTable)\\;version:\\1",
       "js": {
@@ -3095,9 +2475,7 @@
       "website": "https://www.adobe.com/products/dreamweaver.html"
     },
     "Drupal": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:drupal:drupal",
       "headers": {
         "Expires": "19 Nov 1978",
@@ -3117,9 +2495,7 @@
       "website": "https://drupal.org"
     },
     "Drupal Commerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cpe": "cpe:/a:commerceguys:commerce",
       "html": "<[^>]+(?:id=\"block[_-]commerce[_-]cart[_-]cart|class=\"commerce[_-]product[_-]field)",
       "icon": "Drupal Commerce.png",
@@ -3127,11 +2503,7 @@
       "website": "http://drupalcommerce.org"
     },
     "Dynamicweb": {
-      "cats": [
-        1,
-        6,
-        10
-      ],
+      "cats": [1, 6, 10],
       "cookies": {
         "Dynamicweb": ""
       },
@@ -3143,9 +2515,7 @@
       "website": "http://www.dynamicweb.dk"
     },
     "Dynatrace": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "headers": {
         "X-dynaTrace-JS-Agent": ""
       },
@@ -3154,36 +2524,24 @@
       "website": "http://dynatrace.com"
     },
     "EasyEngine": {
-      "cats": [
-        47,
-        9
-      ],
+      "cats": [47, 9],
       "icon": "EasyEngine.png",
-      "implies": [
-        "Docker"
-      ],
+      "implies": ["Docker"],
       "headers": {
         "x-powered-by": "^EasyEngine (.*)$\\;version:\\1"
       },
       "website": "https://easyengine.io"
     },
     "EC-CUBE": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cpe": "cpe:/a:lockon:ec-cube",
       "icon": "ec-cube.png",
       "implies": "PHP",
-      "script": [
-        "eccube\\.js",
-        "win_op\\.js"
-      ],
+      "script": ["eccube\\.js", "win_op\\.js"],
       "website": "http://www.ec-cube.net"
     },
     "Elementor": {
-      "cats": [
-        51
-      ],
+      "cats": [51],
       "html": [
         "<div class=(?:\"|')[^\"']*elementor",
         "<section class=(?:\"|')[^\"']*elementor",
@@ -3199,17 +2557,13 @@
       "website": "https://elementor.com"
     },
     "ELOG": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "<title>ELOG Logbook Selection</title>",
       "icon": "ELOG.png",
       "website": "http://midas.psi.ch/elog"
     },
     "ELOG HTTP": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "ELOG HTTP ?([\\d.-]+)?\\;version:\\1"
       },
@@ -3218,9 +2572,7 @@
       "website": "http://midas.psi.ch/elog"
     },
     "EPages": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-Powered-By": "epages 6"
       },
@@ -3229,9 +2581,7 @@
       "website": "http://www.epages.com/"
     },
     "EPiServer": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "EPiServer": "",
         "EPiTrace": ""
@@ -3245,9 +2595,7 @@
       "website": "http://episerver.com"
     },
     "EPrints": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "EPrints.png",
       "implies": "Perl",
       "js": {
@@ -3260,9 +2608,7 @@
       "website": "http://www.eprints.org"
     },
     "EdgeCast": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Server": "^ECD\\s\\(\\S+\\)"
       },
@@ -3271,23 +2617,16 @@
       "website": "http://www.edgecast.com"
     },
     "Elcodi": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-Elcodi": ""
       },
       "icon": "Elcodi.png",
-      "implies": [
-        "PHP",
-        "Symfony"
-      ],
+      "implies": ["PHP", "Symfony"],
       "website": "http://elcodi.io"
     },
     "Eleanor CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:eleanor-cms:eleanor_cms",
       "icon": "Eleanor CMS.png",
       "implies": "PHP",
@@ -3297,22 +2636,16 @@
       "website": "http://eleanor-cms.ru"
     },
     "Element UI": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "ElementUI.svg",
-      "implies": [
-        "Vue"
-      ],
+      "implies": ["Vue"],
       "html": [
         "<(?:div|button) class=\"el-(?:table-column|table-filter|popper|pagination|pager|select-group|form|form-item|color-predefine|color-hue-slider|color-svpanel|color-alpha-slider|color-dropdown|color-picker|badge|tree|tree-node|select|message|dialog|checkbox|checkbox-button|checkbox-group|container|steps|carousel|menu|menu-item|submenu|menu-item-group|button|button-group|card|table|select-dropdown|row|tabs|notification|radio|progress|progress-bar|tag|popover|tooltip|cascader|cascader-menus|cascader-menu|time-spinner|spinner|spinner-inner|transfer|transfer-panel|rate|slider|dropdown|dropdown-menu|textarea|input|input-group|popup-parent|radio-group|main|breadcrumb|time-range-picker|date-range-picker|year-table|date-editor|range-editor|time-spinner|date-picker|time-panel|date-table|month-table|picker-panel|collapse|collapse-item|alert|select-dropdown|select-dropdown__empty|select-dropdown__wrap|select-dropdown__list|scrollbar|switch|carousel|upload|upload-dragger|upload-list|upload-cover|aside|input-number|header|message-box|footer|radio-button|step|autocomplete|autocomplete-suggestion|loading-parent|loading-mask|loading-spinner|)"
       ],
       "website": "https://element.eleme.io/"
     },
     "Eloqua": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "icon": "Oracle.png",
       "js": {
         "elqCurESite": "",
@@ -3324,9 +2657,7 @@
       "website": "http://eloqua.com"
     },
     "EmbedThis Appweb": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:embedthis:appweb",
       "headers": {
         "Server": "Mbedthis-Appweb(?:/([\\d.]+))?\\;version:\\1"
@@ -3335,9 +2666,7 @@
       "website": "http://embedthis.com/appweb"
     },
     "Ember.js": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "cpe": "cpe:/a:emberjs:ember.js",
       "icon": "Ember.js.png",
       "implies": "Handlebars",
@@ -3348,17 +2677,13 @@
       "website": "http://emberjs.com"
     },
     "Ensighten": {
-      "cats": [
-        42
-      ],
+      "cats": [42],
       "script": "//nexus\\.ensighten\\.com/",
       "icon": "ensighten.png",
       "website": "https://success.ensighten.com/hc/en-us"
     },
     "Envoy": {
-      "cats": [
-        64
-      ],
+      "cats": [64],
       "cpe": "cpe:/a:envoyproxy:envoy",
       "icon": "Envoy.png",
       "headers": {
@@ -3368,10 +2693,7 @@
       "website": "https://www.envoyproxy.io/"
     },
     "Enyo": {
-      "cats": [
-        12,
-        26
-      ],
+      "cats": [12, 26],
       "icon": "Enyo.png",
       "js": {
         "enyo": ""
@@ -3380,18 +2702,14 @@
       "website": "http://enyojs.com"
     },
     "Epoch": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "html": "<link[^>]+?href=\"[^\"]+epoch(?:\\.min)?\\.css",
       "implies": "D3",
       "script": "epoch(?:\\.min)?\\.js",
       "website": "https://fastly.github.io/epoch"
     },
     "Epom": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Epom.png",
       "js": {
         "epomCustomParams": ""
@@ -3400,9 +2718,7 @@
       "website": "http://epom.com"
     },
     "Erlang": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "cpe": "cpe:/a:erlang:erlang%2fotp",
       "headers": {
         "Server": "Erlang( OTP/(?:[\\d.ABR-]+))?\\;version:\\1"
@@ -3411,18 +2727,13 @@
       "website": "http://www.erlang.org"
     },
     "Essential JS 2": {
-      "cats": [
-        12,
-        59
-      ],
+      "cats": [12, 59],
       "html": "<[^>]+ class ?= ?\"(?:e-control|[^\"]+ e-control)(?: )[^\"]* e-lib\\b",
       "icon": "syncfusion.svg",
       "website": "https://www.syncfusion.com/javascript-ui-controls"
     },
     "Etherpad": {
-      "cats": [
-        24
-      ],
+      "cats": [24],
       "cpe": "cpe:/a:etherpad:etherpad",
       "headers": {
         "Server": "^Etherpad"
@@ -3433,15 +2744,11 @@
         "padeditbar": "",
         "padimpexp": ""
       },
-      "script": [
-        "/ep_etherpad-lite/"
-      ],
+      "script": ["/ep_etherpad-lite/"],
       "website": "https://etherpad.org"
     },
     "Exhibit": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "Exhibit.png",
       "js": {
         "Exhibit": "",
@@ -3451,18 +2758,13 @@
       "website": "http://simile-widgets.org/exhibit/"
     },
     "ExpertRec": {
-      "cats": [
-        29
-      ],
+      "cats": [29],
       "icon": "ExpertRec.png",
       "script": "cse\\.expertrec\\.com/api/js/ci_common\\.js\\?id=.*$",
       "website": "https://expertrec.com"
     },
     "Express": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "cpe": "cpe:/a:expressjs:express",
       "headers": {
         "X-Powered-By": "^Express$"
@@ -3472,9 +2774,7 @@
       "website": "http://expressjs.com"
     },
     "ExpressionEngine": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "exp_csrf_token": "",
         "exp_last_activity": "",
@@ -3486,9 +2786,7 @@
       "website": "http://expressionengine.com"
     },
     "ExtJS": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "ExtJS.png",
       "js": {
         "Ext": "",
@@ -3499,9 +2797,7 @@
       "website": "https://www.sencha.com"
     },
     "F5 BigIP": {
-      "cats": [
-        64
-      ],
+      "cats": [64],
       "headers": {
         "server": "^big-?ip$"
       },
@@ -3519,30 +2815,21 @@
       "website": "https://www.f5.com/products/big-ip-services"
     },
     "FAST ESP": {
-      "cats": [
-        29
-      ],
+      "cats": [29],
       "html": "<form[^>]+id=\"fastsearch\"",
       "icon": "FAST ESP.png",
       "website": "http://microsoft.com/enterprisesearch"
     },
     "FAST Search for SharePoint": {
-      "cats": [
-        29
-      ],
+      "cats": [29],
       "html": "<input[^>]+ name=\"ParametricSearch",
       "icon": "FAST Search for SharePoint.png",
-      "implies": [
-        "Microsoft SharePoint",
-        "Microsoft ASP.NET"
-      ],
+      "implies": ["Microsoft SharePoint", "Microsoft ASP.NET"],
       "url": "Pages/SearchResults\\.aspx\\?k=",
       "website": "http://sharepoint.microsoft.com/en-us/product/capabilities/search/Pages/Fast-Search.aspx"
     },
     "FWP": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<!--\\s+FwP Systems",
       "icon": "FWP.png",
       "meta": {
@@ -3551,17 +2838,13 @@
       "website": "http://fwpshop.org"
     },
     "Facebook": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Facebook.svg",
       "script": "//connect\\.facebook\\.net/[^/]*/[a-z]*\\.js",
       "website": "http://facebook.com"
     },
     "Fact Finder": {
-      "cats": [
-        29
-      ],
+      "cats": [29],
       "html": "<!-- Factfinder",
       "icon": "Fact Finder.png",
       "script": "Suggest\\.ff",
@@ -3569,9 +2852,7 @@
       "website": "http://fact-finder.com"
     },
     "FancyBox": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "FancyBox.png",
       "implies": "jQuery",
       "js": {
@@ -3581,9 +2862,7 @@
       "website": "http://fancyapps.com/fancybox"
     },
     "Fastcommerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Fastcommerce.png",
       "meta": {
         "generator": "^Fastcommerce"
@@ -3591,9 +2870,7 @@
       "website": "https://www.fastcommerce.com.br"
     },
     "Fastly": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Fastly-Debug-Digest": "",
         "Vary": "Fastly-SSL",
@@ -3604,9 +2881,7 @@
       "website": "https://www.fastly.com"
     },
     "Fat-Free Framework": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Powered-By": "^Fat-Free Framework$"
       },
@@ -3615,9 +2890,7 @@
       "website": "http://fatfreeframework.com"
     },
     "Fbits": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Fbits.png",
       "js": {
         "fbits": ""
@@ -3625,9 +2898,7 @@
       "website": "https://www.traycorp.com.br"
     },
     "Fedora": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "cpe": "cpe:/o:fedoraproject:fedora",
       "headers": {
         "Server": "Fedora"
@@ -3636,9 +2907,7 @@
       "website": "http://fedoraproject.org"
     },
     "Fingerprintjs": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "js": {
         "Fingerprint": "(\\d)?$\\;version:\\1",
         "Fingerprint2": "",
@@ -3648,9 +2917,7 @@
       "website": "https://valve.github.io/fingerprintjs2/"
     },
     "Firebase": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "icon": "Firebase.png",
       "js": {
         "firebase.SDK_VERSION": "([\\d.]+)$\\;version:\\1"
@@ -3659,9 +2926,7 @@
       "website": "https://firebase.com"
     },
     "Fireblade": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Server": "fbs"
       },
@@ -3669,16 +2934,11 @@
       "website": "http://fireblade.com"
     },
     "Flarum": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "cpe": "cpe:/a:flarum:flarum",
       "html": "<div id=\"flarum-loading\"",
       "icon": "flarum.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "js": {
         "app.cache.discussionList": "",
         "app.forum.freshness": ""
@@ -3686,10 +2946,7 @@
       "website": "http://flarum.org/"
     },
     "Flask": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "headers": {
         "Server": "Werkzeug/?([\\d\\.]+)?\\;version:\\1"
       },
@@ -3698,18 +2955,14 @@
       "website": "http://flask.pocoo.org"
     },
     "Flat UI": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": "<link[^>]* href=[^>]+flat-ui(?:\\.min)?\\.css",
       "icon": "Flat UI.png",
       "implies": "Bootstrap",
       "website": "https://designmodo.github.io/Flat-UI/"
     },
     "FlexCMP": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Flex-Lang": "",
         "X-Powered-By": "FlexCMP.+\\[v\\. ([\\d.]+)\\;version:\\1"
@@ -3722,20 +2975,14 @@
       "website": "http://www.flexcmp.com/cms/home"
     },
     "FlexSlider": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "FlexSlider.png",
       "implies": "jQuery",
-      "script": [
-        "jquery\\.flexslider(?:\\.min)?\\.js$"
-      ],
+      "script": ["jquery\\.flexslider(?:\\.min)?\\.js$"],
       "website": "https://woocommerce.com/flexslider/"
     },
     "Flickity": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "js": {
         "Flickity": ""
       },
@@ -3743,9 +2990,7 @@
       "website": "https://flickity.metafizzy.co/"
     },
     "FluxBB": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "cpe": "cpe:/a:fluxbb:fluxbb",
       "html": "<p id=\"poweredby\">[^<]+<a href=\"https?://fluxbb\\.org/\">",
       "icon": "FluxBB.png",
@@ -3753,9 +2998,7 @@
       "website": "https://fluxbb.org"
     },
     "Flyspray": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "cookies": {
         "flyspray_project": ""
       },
@@ -3765,9 +3008,7 @@
       "website": "http://flyspray.org"
     },
     "Flywheel": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "x-fw-hash": "",
         "x-fw-serve": "",
@@ -3775,16 +3016,12 @@
         "x-fw-static": "",
         "x-fw-type": ""
       },
-      "implies": [
-        "WordPress"
-      ],
+      "implies": ["WordPress"],
       "icon": "flywheel.svg",
       "website": "https://getflywheel.com"
     },
     "Font Awesome": {
-      "cats": [
-        17
-      ],
+      "cats": [17],
       "html": [
         "<link[^>]* href=[^>]+(?:([\\d.]+)/)?(?:css/)?font-awesome(?:\\.min)?\\.css\\;version:\\1",
         "<link[^>]* href=\"https://use\\.fontawesome\\.com/releases/v([^>]+)/css/\\;version:\\1",
@@ -3794,9 +3031,7 @@
       "website": "http://fontawesome.io"
     },
     "Fork CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:fork-cms:fork_cms",
       "icon": "ForkCMS.png",
       "implies": "Symfony",
@@ -3806,18 +3041,14 @@
       "website": "http://www.fork-cms.com/"
     },
     "Fortune3": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "(?:<link [^>]*href=\"[^\\/]*\\/\\/www\\.fortune3\\.com\\/[^\"]*siterate\\/rate\\.css|Powered by <a [^>]*href=\"[^\"]+fortune3\\.com)",
       "icon": "Fortune3.png",
       "script": "cartjs\\.php\\?(?:.*&)?s=[^&]*myfortune3cart\\.com",
       "website": "http://fortune3.com"
     },
     "Foswiki": {
-      "cats": [
-        8
-      ],
+      "cats": [8],
       "cookies": {
         "FOSWIKISTRIKEONE": "",
         "SFOSWIKISID": ""
@@ -3827,9 +3058,7 @@
         "X-Foswikiaction": "",
         "X-Foswikiuri": ""
       },
-      "html": [
-        "<div class=\"foswiki(?:Copyright|Page|Main)\">"
-      ],
+      "html": ["<div class=\"foswiki(?:Copyright|Page|Main)\">"],
       "icon": "foswiki.png",
       "implies": "Perl",
       "js": {
@@ -3842,9 +3071,7 @@
       "website": "http://foswiki.org"
     },
     "FreeBSD": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "cpe": "cpe:/o:freebsd:freebsd",
       "headers": {
         "Server": "FreeBSD(?: ([\\d.]+))?\\;version:\\1"
@@ -3853,9 +3080,7 @@
       "website": "http://freebsd.org"
     },
     "FreeTextBox": {
-      "cats": [
-        24
-      ],
+      "cats": [24],
       "html": "/<!--\\s*\\*\\s*FreeTextBox v\\d+ \\(([.\\d]+)(?:(?:.|\\n)+?<!--\\s*\\*\\s*License Type: (Distribution|Professional)License)?/i\\;version:\\1 \\2",
       "icon": "FreeTextBox.png",
       "implies": "Microsoft ASP.NET",
@@ -3866,45 +3091,32 @@
       "website": "http://freetextbox.com"
     },
     "Freespee": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Freespee.svg",
       "script": "analytics\\.freespee\\.com/js/external/fs\\.(?:min\\.)?js",
       "website": "https://www.freespee.com"
     },
     "Freshchat": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "freshchat.png",
       "script": "wchat\\.freshchat\\.com/js/widget\\.js",
       "website": "https://www.freshworks.com/live-chat-software/"
     },
     "Freshmarketer": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "freshmarketer.png",
       "script": "cdn\\.freshmarketer\\.com",
       "website": "https://www.freshworks.com/marketing-automation/conversion-rate-optimization/"
     },
     "Froala Editor": {
-      "cats": [
-        24
-      ],
+      "cats": [24],
       "html": "<[^>]+class=\"[^\"]*(?:fr-view|fr-box)",
       "icon": "Froala.svg",
-      "implies": [
-        "jQuery",
-        "Font Awesome"
-      ],
+      "implies": ["jQuery", "Font Awesome"],
       "website": "http://froala.com/wysiwyg-editor"
     },
     "FrontPage": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "cpe": "cpe:/a:microsoft:frontpage",
       "icon": "FrontPage.png",
       "meta": {
@@ -3914,9 +3126,7 @@
       "website": "http://office.microsoft.com/frontpage"
     },
     "Fusion Ads": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Fusion Ads.png",
       "js": {
         "_fusion": ""
@@ -3925,17 +3135,13 @@
       "website": "http://fusionads.net"
     },
     "Future Shop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "futureshop.png",
       "script": "future-shop.*\\.js",
       "website": "https://www.future-shop.jp"
     },
     "G-WAN": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "G-WAN"
       },
@@ -3943,9 +3149,7 @@
       "website": "http://gwan.com"
     },
     "GX WebManager": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<!--\\s+Powered by GX",
       "icon": "GX WebManager.png",
       "meta": {
@@ -3954,9 +3158,7 @@
       "website": "http://www.gxsoftware.com/en/products/web-content-management.htm"
     },
     "Gallery": {
-      "cats": [
-        7
-      ],
+      "cats": [7],
       "html": [
         "<div id=\"gsNavBar\" class=\"gcBorder1\">",
         "<a href=\"http://gallery\\.sourceforge\\.net\"><img[^>]+Powered by Gallery\\s*(?:(?:v|Version)\\s*([0-9.]+))?\\;version:\\1"
@@ -3969,9 +3171,7 @@
       "website": "http://galleryproject.org/"
     },
     "Gambio": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "(?:<link[^>]* href=\"templates/gambio/|<a[^>]content\\.php\\?coID=\\d|<!-- gambio eof -->|<!--[\\s=]+Shopsoftware by Gambio GmbH \\(c\\))",
       "icon": "Gambio.png",
       "implies": "PHP",
@@ -3982,28 +3182,17 @@
       "website": "http://gambio.de"
     },
     "Gatsby": {
-      "cats": [
-        57,
-        12
-      ],
-      "html": [
-        "<div id=\"___gatsby\">",
-        "<style id=\"gatsby-inlined-css\">"
-      ],
+      "cats": [57, 12],
+      "html": ["<div id=\"___gatsby\">", "<style id=\"gatsby-inlined-css\">"],
       "meta": {
         "generator": "^Gatsby(?: ([0-9.]+))?$\\;version:\\1"
       },
       "icon": "Gatsby.svg",
-      "implies": [
-        "React",
-        "webpack"
-      ],
+      "implies": ["React", "webpack"],
       "website": "https://www.gatsbyjs.org/"
     },
     "Gauges": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "cookies": {
         "_gauges_": ""
       },
@@ -4014,9 +3203,7 @@
       "website": "https://get.gaug.es"
     },
     "Gemius": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Gemius.png",
       "js": {
         "pp_gemius_hit": "",
@@ -4033,9 +3220,7 @@
       "website": "https://www.gemius.com"
     },
     "Gentoo": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "cpe": "cpe:/o:gentoo:linux",
       "headers": {
         "X-Powered-By": "gentoo"
@@ -4044,18 +3229,13 @@
       "website": "http://www.gentoo.org"
     },
     "Gerrit": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "html": [
         ">Gerrit Code Review</a>\\s*\"\\s*\\(([0-9.]+)\\)\\;version:\\1",
         "<(?:div|style) id=\"gerrit_"
       ],
       "icon": "gerrit.svg",
-      "implies": [
-        "Java",
-        "git"
-      ],
+      "implies": ["Java", "git"],
       "js": {
         "Gerrit": "",
         "gerrit_ui": ""
@@ -4067,9 +3247,7 @@
       "website": "http://www.gerritcodereview.com"
     },
     "Get Satisfaction": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "icon": "Get Satisfaction.png",
       "js": {
         "GSFN": ""
@@ -4077,9 +3255,7 @@
       "website": "https://getsatisfaction.com/corp/"
     },
     "GetSimple CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:get-simple:getsimple_cms",
       "icon": "GetSimple CMS.png",
       "implies": "PHP",
@@ -4089,9 +3265,7 @@
       "website": "http://get-simple.info"
     },
     "Ghost": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "headers": {
         "X-Ghost-Cache-Status": ""
       },
@@ -4103,9 +3277,7 @@
       "website": "http://ghost.org"
     },
     "GitBook": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "icon": "GitBook.png",
       "meta": {
         "generator": "GitBook(?:.([\\d.]+))?\\;version:\\1"
@@ -4114,25 +3286,18 @@
       "website": "https://www.gitbook.com"
     },
     "GitHub Pages": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "Server": "^GitHub\\.com$",
         "X-GitHub-Request-Id": ""
       },
       "icon": "GitHub.svg",
-      "implies": [
-        "Ruby on Rails"
-      ],
+      "implies": ["Ruby on Rails"],
       "url": "^https?://[^/]+\\.github\\.io/",
       "website": "https://pages.github.com/"
     },
     "GitLab": {
-      "cats": [
-        13,
-        47
-      ],
+      "cats": [13, 47],
       "cookies": {
         "_gitlab_session": ""
       },
@@ -4152,10 +3317,7 @@
       "website": "https://about.gitlab.com"
     },
     "GitLab CI": {
-      "cats": [
-        44,
-        47
-      ],
+      "cats": [44, 47],
       "icon": "GitLab CI.png",
       "implies": "Ruby on Rails",
       "meta": {
@@ -4164,9 +3326,7 @@
       "website": "http://about.gitlab.com/gitlab-ci"
     },
     "Gitea": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "cookies": {
         "i_like_gitea": ""
       },
@@ -4181,50 +3341,35 @@
       "website": "https://gitea.io"
     },
     "Gitiles": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "html": "Powered by <a href=\"https://gerrit\\.googlesource\\.com/gitiles/\">Gitiles<",
-      "implies": [
-        "Java",
-        "git"
-      ],
+      "implies": ["Java", "git"],
       "website": "http://gerrit.googlesource.com/gitiles/"
     },
     "GlassFish": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:oracle:glassfish_server",
       "headers": {
         "Server": "GlassFish(?: Server)?(?: Open Source Edition)?(?: ?/?([\\d.]+))?\\;version:\\1"
       },
       "icon": "GlassFish.png",
-      "implies": [
-        "Java"
-      ],
+      "implies": ["Java"],
       "website": "http://glassfish.java.net"
     },
     "Glyphicons": {
-      "cats": [
-        17
-      ],
+      "cats": [17],
       "html": "(?:<link[^>]* href=[^>]+glyphicons(?:\\.min)?\\.css|<img[^>]* src=[^>]+glyphicons)",
       "icon": "Glyphicons.png",
       "website": "http://glyphicons.com"
     },
     "Go": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "cpe": "cpe:/a:golang:go",
       "icon": "Go.svg",
       "website": "https://golang.org"
     },
     "GoAhead": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:embedthis:goahead",
       "headers": {
         "Server": "GoAhead"
@@ -4233,9 +3378,7 @@
       "website": "http://embedthis.com/products/goahead/index.html"
     },
     "GoDaddy Website Builder": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "dps_site_id": ""
       },
@@ -4246,9 +3389,7 @@
       "website": "https://www.godaddy.com/websites/website-builder"
     },
     "GoJS": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "GoJS.png",
       "website": "https://gojs.net/",
       "js": {
@@ -4257,11 +3398,7 @@
       }
     },
     "GoSquared": {
-      "cats": [
-        10,
-        52,
-        53
-      ],
+      "cats": [10, 52, 53],
       "icon": "gosquared.png",
       "js": {
         "_gs": "\\;confidence:30"
@@ -4269,9 +3406,7 @@
       "website": "https://www.gosquared.com/"
     },
     "GoStats": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "GoStats.png",
       "js": {
         "_goStatsRun": "",
@@ -4281,9 +3416,7 @@
       "website": "http://gostats.com/"
     },
     "Gogs": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "cookies": {
         "i_like_gogits": ""
       },
@@ -4300,9 +3433,7 @@
       "website": "http://gogs.io"
     },
     "Google AdSense": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Google AdSense.svg",
       "js": {
         "Goog_AdSense_": "",
@@ -4318,9 +3449,7 @@
       "website": "https://www.google.fr/adsense/start/"
     },
     "Google Analytics": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "cookies": {
         "__utma": "",
         "_ga": "",
@@ -4336,9 +3465,7 @@
       "website": "http://google.com/analytics"
     },
     "Google Analytics Enhanced eCommerce": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Google Analytics.svg",
       "implies": "Google Analytics",
       "js": {
@@ -4348,9 +3475,7 @@
       "website": "https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce"
     },
     "Google App Engine": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Google Frontend"
       },
@@ -4358,9 +3483,7 @@
       "website": "http://code.google.com/appengine"
     },
     "Google Charts": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "Google Charts.png",
       "js": {
         "__googleVisualizationAbstractRendererElementsCount__": "",
@@ -4369,9 +3492,7 @@
       "website": "http://developers.google.com/chart/"
     },
     "Google Cloud": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "cpe": "cpe:/a:google:cloud_platform",
       "headers": {
         "Via": "^1\\.1 google$"
@@ -4380,9 +3501,7 @@
       "website": "https://cloud.google.com"
     },
     "Google Code Prettify": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "Google.svg",
       "js": {
         "prettyPrint": ""
@@ -4390,9 +3509,7 @@
       "website": "http://code.google.com/p/google-code-prettify"
     },
     "Google Font API": {
-      "cats": [
-        17
-      ],
+      "cats": [17],
       "html": "<link[^>]* href=[^>]+fonts\\.(?:googleapis|google)\\.com",
       "icon": "Google Font API.png",
       "js": {
@@ -4402,9 +3519,7 @@
       "website": "http://google.com/fonts"
     },
     "Google Maps": {
-      "cats": [
-        35
-      ],
+      "cats": [35],
       "icon": "Google Maps.png",
       "script": [
         "(?:maps\\.google\\.com/maps\\?file=api(?:&v=([\\d.]+))?|maps\\.google\\.com/maps/api/staticmap)\\;version:API v\\1",
@@ -4413,10 +3528,7 @@
       "website": "http://maps.google.com"
     },
     "Google PageSpeed": {
-      "cats": [
-        23,
-        33
-      ],
+      "cats": [23, 33],
       "headers": {
         "X-Mod-Pagespeed": "([\\d.]+)\\;version:\\1",
         "X-Page-Speed": "(.+)\\;version:\\1"
@@ -4425,25 +3537,19 @@
       "website": "http://developers.google.com/speed/pagespeed/mod"
     },
     "Google Plus": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Google Plus.svg",
       "script": "apis\\.google\\.com/js/[a-z]*\\.js",
       "website": "http://plus.google.com"
     },
     "Google Sites": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Google Sites.png",
       "url": "^https?://sites\\.google\\.com",
       "website": "http://sites.google.com"
     },
     "Google Tag Manager": {
-      "cats": [
-        42
-      ],
+      "cats": [42],
       "html": [
         "googletagmanager\\.com/ns\\.html[^>]+></iframe>",
         "<!-- (?:End )?Google Tag Manager -->"
@@ -4456,20 +3562,13 @@
       "website": "http://www.google.com/tagmanager"
     },
     "Google Wallet": {
-      "cats": [
-        41
-      ],
+      "cats": [41],
       "icon": "Google Wallet.png",
-      "script": [
-        "checkout\\.google\\.com",
-        "wallet\\.google\\.com"
-      ],
+      "script": ["checkout\\.google\\.com", "wallet\\.google\\.com"],
       "website": "http://wallet.google.com"
     },
     "Google Web Server": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:google:web_server",
       "headers": {
         "Server": "gws"
@@ -4478,9 +3577,7 @@
       "website": "http://en.wikipedia.org/wiki/Google_Web_Server"
     },
     "Google Web Toolkit": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cpe": "cpe:/a:google:web_toolkit",
       "icon": "Google Web Toolkit.png",
       "implies": "Java",
@@ -4498,9 +3595,7 @@
       "website": "http://developers.google.com/web-toolkit"
     },
     "Graffiti CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "graffitibot": ""
       },
@@ -4513,9 +3608,7 @@
       "website": "http://graffiticms.codeplex.com"
     },
     "Grav": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Grav.png",
       "implies": "PHP",
       "meta": {
@@ -4524,9 +3617,7 @@
       "website": "http://getgrav.org"
     },
     "Gravatar": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "<[^>]+gravatar\\.com/avatar/",
       "icon": "Gravatar.png",
       "js": {
@@ -4535,9 +3626,7 @@
       "website": "http://gravatar.com"
     },
     "Gravity Forms": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": [
         "<div class=(?:\"|')[^>]*gform_wrapper",
         "<div class=(?:\"|')[^>]*gform_body",
@@ -4550,9 +3639,7 @@
       "website": "http://gravityforms.com"
     },
     "Green Valley CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<img[^>]+/dsresource\\?objectid=",
       "icon": "Green Valley CMS.png",
       "implies": "Apache Tomcat",
@@ -4562,9 +3649,7 @@
       "website": "http://www.greenvalley.nl/Public/Producten/Content_Management/CMS"
     },
     "Gridsome": {
-      "cats": [
-        57
-      ],
+      "cats": [57],
       "icon": "Gridsome.svg",
       "implies": "Vue.js",
       "meta": {
@@ -4573,9 +3658,7 @@
       "website": "https://gridsome.org"
     },
     "GrowingIO": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "js": {
         "gio": ""
       },
@@ -4588,17 +3671,13 @@
       "website": "https://www.growingio.com/"
     },
     "HERE": {
-      "cats": [
-        35
-      ],
+      "cats": [35],
       "icon": "HERE.png",
       "script": "https?://js\\.cit\\.api\\.here\\.com/se/([\\d.]+)\\/\\;version:\\1",
       "website": "http://developer.here.com"
     },
     "HHVM": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:facebook:hhvm",
       "headers": {
         "X-Powered-By": "HHVM/?([\\d.]+)?\\;version:\\1"
@@ -4608,9 +3687,7 @@
       "website": "http://hhvm.com"
     },
     "HP ChaiServer": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "HP-Chai(?:Server|SOE)(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -4618,9 +3695,7 @@
       "website": "http://hp.com"
     },
     "HP Compact Server": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "HP_Compact_Server(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -4628,17 +3703,13 @@
       "website": "http://hp.com"
     },
     "HP ProCurve": {
-      "cats": [
-        37
-      ],
+      "cats": [37],
       "cpe": "cpe:/h:hp:procurve_switch",
       "icon": "HP.svg",
       "website": "http://hp.com/networking"
     },
     "HP System Management": {
-      "cats": [
-        46
-      ],
+      "cats": [46],
       "headers": {
         "Server": "HP System Management"
       },
@@ -4646,10 +3717,7 @@
       "website": "http://hp.com"
     },
     "HP iLO": {
-      "cats": [
-        22,
-        46
-      ],
+      "cats": [22, 46],
       "headers": {
         "Server": "HP-iLO-Server(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -4657,9 +3725,7 @@
       "website": "http://hp.com"
     },
     "HTTP/2": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "excludes": "SPDY",
       "headers": {
         "X-Firefox-Spdy": "h2"
@@ -4668,17 +3734,13 @@
       "website": "https://http2.github.io"
     },
     "Haddock": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "html": "<p>Produced by <a href=\"http://www\\.haskell\\.org/haddock/\">Haddock</a> version ([0-9.]+)</p>\\;version:\\1",
       "script": "haddock-util\\.js",
       "website": "http://www.haskell.org/haddock/"
     },
     "Hammer.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Hammer.js.png",
       "js": {
         "Ha.VERSION": "^(.+)$\\;version:\\1",
@@ -4689,9 +3751,7 @@
       "website": "https://hammerjs.github.io"
     },
     "Handlebars": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "html": "<[^>]*type=[^>]text\\/x-handlebars-template",
       "icon": "Handlebars.png",
       "js": {
@@ -4702,9 +3762,7 @@
       "website": "http://handlebarsjs.com"
     },
     "Haravan": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Haravan.png",
       "js": {
         "Haravan": ""
@@ -4713,16 +3771,12 @@
       "website": "https://www.haravan.com"
     },
     "Haskell": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "icon": "Haskell.png",
       "website": "http://wiki.haskell.org/Haskell"
     },
     "HeadJS": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "html": "<[^>]*data-headjs-load",
       "icon": "HeadJS.png",
       "js": {
@@ -4732,9 +3786,7 @@
       "website": "http://headjs.com"
     },
     "Heap": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Heap.png",
       "js": {
         "heap": ""
@@ -4743,9 +3795,7 @@
       "website": "http://heapanalytics.com"
     },
     "Hello Bar": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Hello Bar.png",
       "js": {
         "HelloBar": ""
@@ -4754,12 +3804,8 @@
       "website": "http://hellobar.com"
     },
     "Hexo": {
-      "cats": [
-        57
-      ],
-      "html": [
-        "Powered by <a href=\"https?://hexo\\.io/?\"[^>]*>Hexo</"
-      ],
+      "cats": [57],
+      "html": ["Powered by <a href=\"https?://hexo\\.io/?\"[^>]*>Hexo</"],
       "icon": "Hexo.png",
       "meta": {
         "generator": "Hexo(?: v?([\\d.]+))?\\;version:\\1"
@@ -4767,9 +3813,7 @@
       "website": "https://hexo.io"
     },
     "Hiawatha": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Hiawatha v([\\d.]+)\\;version:\\1"
       },
@@ -4777,9 +3821,7 @@
       "website": "http://hiawatha-webserver.org"
     },
     "Highcharts": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "html": "<svg[^>]*><desc>Created with Highcharts ([\\d.]*)\\;version:\\1",
       "icon": "Highcharts.png",
       "js": {
@@ -4790,9 +3832,7 @@
       "website": "https://www.highcharts.com"
     },
     "Bokeh": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "js": {
         "Bokeh": "",
         "Bokeh.version": "^(.+)$\\;version:\\1"
@@ -4800,14 +3840,10 @@
       "script": "bokeh.*\\.js",
       "website": "https://bokeh.org",
       "icon": "bokeh.png",
-      "implies": [
-        "Python"
-      ]
+      "implies": ["Python"]
     },
     "Highlight.js": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "Highlight.js.png",
       "js": {
         "hljs.highlightBlock": "",
@@ -4817,19 +3853,14 @@
       "website": "https://highlightjs.org/"
     },
     "Highstock": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "html": "<svg[^>]*><desc>Created with Highstock ([\\d.]*)\\;version:\\1",
       "icon": "Highcharts.png",
       "script": "highstock[.-]?([\\d\\.]*\\d).*\\.js\\;version:\\1",
       "website": "http://highcharts.com/products/highstock"
     },
     "Hinza Advanced CMS": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "icon": "hinza_advanced_cms.svg",
       "implies": "Laravel",
       "meta": {
@@ -4838,17 +3869,13 @@
       "website": "http://hinzaco.com"
     },
     "Bloomreach": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<[^>]+/binaries/(?:[^/]+/)*content/gallery/",
       "icon": "Bloomreach.png",
       "website": "https://developers.bloomreach.com"
     },
     "Hogan.js": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Hogan.js.png",
       "js": {
         "Hogan": ""
@@ -4860,10 +3887,7 @@
       "website": "https://twitter.github.io/hogan.js/"
     },
     "Homeland": {
-      "cats": [
-        1,
-        2
-      ],
+      "cats": [1, 2],
       "cookies": {
         "_homeland_": ""
       },
@@ -4872,9 +3896,7 @@
       "website": "https://gethomeland.com"
     },
     "Hotaru CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "hotaru_mobile": ""
       },
@@ -4886,9 +3908,7 @@
       "website": "http://hotarucms.org"
     },
     "Hotjar": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Hotjar.png",
       "js": {
         "HotLeadfactory": "",
@@ -4899,9 +3919,7 @@
       "website": "https://www.hotjar.com"
     },
     "HubSpot": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "html": "<!-- Start of Async HubSpot",
       "icon": "HubSpot.png",
       "js": {
@@ -4911,9 +3929,7 @@
       "website": "https://www.hubspot.com"
     },
     "Hugo": {
-      "cats": [
-        57
-      ],
+      "cats": [57],
       "html": "powered by <a [^>]*href=\"http://hugo.spf13.com",
       "icon": "Hugo.png",
       "meta": {
@@ -4922,9 +3938,7 @@
       "website": "http://gohugo.io"
     },
     "Hybris": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "_hybris": ""
       },
@@ -4935,17 +3949,13 @@
       "website": "https://hybris.com"
     },
     "IBM Coremetrics": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "IBM.svg",
       "script": "cmdatatagutils\\.js",
       "website": "http://ibm.com/software/marketing-solutions/coremetrics"
     },
     "IBM DataPower": {
-      "cats": [
-        64
-      ],
+      "cats": [64],
       "cpe": "cpe:/a:ibm:datapower_gateway",
       "headers": {
         "X-Backside-Transport": "",
@@ -4955,9 +3965,7 @@
       "website": "https://www.ibm.com/products/datapower-gateway"
     },
     "IBM HTTP Server": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:ibm:http_server",
       "headers": {
         "Server": "IBM_HTTP_Server(?:/([\\d.]+))?\\;version:\\1"
@@ -4966,9 +3974,7 @@
       "website": "http://ibm.com/software/webservers/httpservers"
     },
     "IBM Tivoli Storage Manager": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:ibm:tivoli_storage_manager",
       "headers": {
         "Server": "TSM_HTTP(?:/([\\d.]+))?\\;version:\\1"
@@ -4977,9 +3983,7 @@
       "website": "http://ibm.com"
     },
     "IBM WebSphere Commerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cpe": "cpe:/a:ibm:websphere_commerce_suite",
       "html": "href=\"(?:\\/|[^>]+)webapp\\/wcs\\/",
       "icon": "IBM.svg",
@@ -4988,9 +3992,7 @@
       "website": "http://ibm.com/software/genservers/commerceproductline"
     },
     "IBM WebSphere Portal": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:ibm:websphere_portal",
       "headers": {
         "IBM-Web2-Location": "",
@@ -5002,9 +4004,7 @@
       "website": "http://ibm.com/software/websphere/portal"
     },
     "IIS": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:microsoft:internet_information_server",
       "headers": {
         "Server": "^(?:Microsoft-)?IIS(?:/([\\d.]+))?\\;version:\\1"
@@ -5014,9 +4014,7 @@
       "website": "http://www.iis.net"
     },
     "INFOnline": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "INFOnline.png",
       "js": {
         "iam_data": "",
@@ -5026,28 +4024,20 @@
       "website": "https://www.infonline.de"
     },
     "INTI": {
-      "cats": [
-        6,
-        53
-      ],
+      "cats": [6, 53],
       "icon": "byINTI.svg",
       "url": "\\.byinti\\.com",
       "website": "https://byinti.com"
     },
     "IPB": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "cookies": {
         "ipbWWLmodpids": "",
         "ipbWWLsession_id": ""
       },
       "html": "<link[^>]+ipb_[^>]+\\.css",
       "icon": "IPB.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "js": {
         "IPBoard": "",
         "ipb_var": "",
@@ -5057,19 +4047,13 @@
       "website": "https://invisioncommunity.com/"
     },
     "Ideasoft": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Ideasoft.png",
-      "script": [
-        "\\.myideasoft\\.com/"
-      ],
+      "script": ["\\.myideasoft\\.com/"],
       "website": "https://www.ideasoft.com"
     },
     "IdoSell Shop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "idosellshop.png",
       "js": {
         "IAI_Ajax": ""
@@ -5077,9 +4061,7 @@
       "website": "https://www.idosell.com"
     },
     "Immutable.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Immutable.js.png",
       "js": {
         "Immutable": "",
@@ -5089,9 +4071,7 @@
       "website": "https://facebook.github.io/immutable-js/"
     },
     "ImpressCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "ICMSSession": "",
         "ImpressCMS": ""
@@ -5106,9 +4086,7 @@
       "website": "http://www.impresscms.org"
     },
     "ImpressPages": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:impresspages:impresspages_cms",
       "icon": "ImpressPages.png",
       "implies": "PHP",
@@ -5118,9 +4096,7 @@
       "website": "http://impresspages.org"
     },
     "Incapsula": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "X-CDN": "Incapsula"
       },
@@ -5128,9 +4104,7 @@
       "website": "http://www.incapsula.com"
     },
     "PageCDN": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "X-CDN": "PageCDN"
       },
@@ -5138,9 +4112,7 @@
       "website": "https://pagecdn.com"
     },
     "Includable": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Includable-Version": ""
       },
@@ -5148,25 +4120,17 @@
       "website": "http://includable.com"
     },
     "Indexhibit": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:indexhibit:indexhibit",
       "html": "<(?:link|a href) [^>]+ndxz-studio",
-      "implies": [
-        "PHP",
-        "Apache",
-        "Exhibit"
-      ],
+      "implies": ["PHP", "Apache", "Exhibit"],
       "meta": {
         "generator": "Indexhibit"
       },
       "website": "http://www.indexhibit.org"
     },
     "Indico": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "MAKACSESSION": ""
       },
@@ -5175,18 +4139,14 @@
       "website": "http://indico-software.org"
     },
     "Indy": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Indy(?:/([\\d.]+))?\\;version:\\1"
       },
       "website": "http://indyproject.org"
     },
     "InfernoJS": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "InfernoJS.png",
       "js": {
         "Inferno": "",
@@ -5195,9 +4155,7 @@
       "website": "https://infernojs.org"
     },
     "Infusionsoft": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "cpe": "cpe:/a:infusionsoft_project:infusionsoft",
       "html": [
         "<input [^>]*name=\"infusionsoft_version\" [^>]*value=\"([^>]*)\" [^>]*\\/>\\;version:\\1",
@@ -5207,30 +4165,18 @@
       "website": "http://infusionsoft.com"
     },
     "Inspectlet": {
-      "cats": [
-        10
-      ],
-      "html": [
-        "<!-- (?:Begin|End) Inspectlet Embed Code -->"
-      ],
+      "cats": [10],
+      "html": ["<!-- (?:Begin|End) Inspectlet Embed Code -->"],
       "icon": "inspectlet.png",
       "js": {
         "__insp": "",
         "__inspld": ""
       },
-      "script": [
-        "cdn\\.inspectlet\\.com"
-      ],
+      "script": ["cdn\\.inspectlet\\.com"],
       "website": "https://www.inspectlet.com/"
     },
     "Instabot": {
-      "cats": [
-        5,
-        10,
-        32,
-        52,
-        58
-      ],
+      "cats": [5, 10, 32, 52, 58],
       "icon": "Instabot.png",
       "js": {
         "Instabot": ""
@@ -5239,9 +4185,7 @@
       "website": "https://instabot.io/"
     },
     "InstantCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "InstantCMS[logdate]": ""
       },
@@ -5254,10 +4198,7 @@
       "website": "http://www.instantcms.ru"
     },
     "Intel Active Management Technology": {
-      "cats": [
-        22,
-        46
-      ],
+      "cats": [22, 46],
       "cpe": "cpe:/a:intel:active_management_technology",
       "headers": {
         "Server": "Intel\\(R\\) Active Management Technology(?: ([\\d.]+))?\\;version:\\1"
@@ -5266,17 +4207,13 @@
       "website": "http://intel.com"
     },
     "IntenseDebate": {
-      "cats": [
-        15
-      ],
+      "cats": [15],
       "icon": "IntenseDebate.png",
       "script": "intensedebate\\.com",
       "website": "http://intensedebate.com"
     },
     "Intercom": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Intercom.png",
       "js": {
         "Intercom": ""
@@ -5285,18 +4222,14 @@
       "website": "https://www.intercom.com"
     },
     "Intershop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Intershop.png",
       "html": "<ish-root",
       "script": "(?:is-bin|INTERSHOP)",
       "website": "http://intershop.com"
     },
     "Invenio": {
-      "cats": [
-        50
-      ],
+      "cats": [50],
       "cookies": {
         "INVENIOSESSION": ""
       },
@@ -5305,9 +4238,7 @@
       "website": "http://invenio-software.org"
     },
     "Inwemo": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "icon": "inwemo.png",
       "js": {
         "Inwemo": ""
@@ -5316,9 +4247,7 @@
       "website": "https://inwemo.com/"
     },
     "Ionic": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "icon": "ionic.png",
       "implies": "Angular",
       "js": {
@@ -5328,17 +4257,13 @@
       "website": "https://ionicframework.com"
     },
     "Ionicons": {
-      "cats": [
-        17
-      ],
+      "cats": [17],
       "html": "<link[^>]* href=[^>]+ionicons(?:\\.min)?\\.css",
       "icon": "Ionicons.png",
       "website": "http://ionicons.com"
     },
     "JAlbum": {
-      "cats": [
-        7
-      ],
+      "cats": [7],
       "icon": "JAlbum.png",
       "implies": "Java",
       "meta": {
@@ -5347,9 +4272,7 @@
       "website": "http://jalbum.net/en"
     },
     "JBoss Application Server": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "X-Powered-By": "JBoss(?:-([\\d.]+))?\\;version:\\1"
       },
@@ -5357,9 +4280,7 @@
       "website": "http://jboss.org/jbossas.html"
     },
     "JBoss Web": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "excludes": "Apache Tomcat",
       "headers": {
         "X-Powered-By": "JBossWeb(?:-([\\d.]+))?\\;version:\\1"
@@ -5369,9 +4290,7 @@
       "website": "http://jboss.org/jbossweb"
     },
     "JET Enterprise": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "powered": "jet-enterprise"
       },
@@ -5379,9 +4298,7 @@
       "website": "http://www.jetecommerce.com.br/"
     },
     "JS Charts": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "JS Charts.png",
       "js": {
         "JSChart": ""
@@ -5390,9 +4307,7 @@
       "website": "http://www.jscharts.com"
     },
     "JSEcoin": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "icon": "JSEcoin.png",
       "js": {
         "jseMine": ""
@@ -5401,9 +4316,7 @@
       "website": "https://jsecoin.com/"
     },
     "JTL Shop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "JTLSHOP": ""
       },
@@ -5412,18 +4325,13 @@
       "website": "http://www.jtl-software.de/produkte/jtl-shop3"
     },
     "Jahia DX": {
-      "cats": [
-        1,
-        47
-      ],
+      "cats": [1, 47],
       "html": "<script id=\"staticAssetAggregatedJavascrip",
       "icon": "JahiaDX.svg",
       "website": "http://www.jahia.com/dx"
     },
     "Jalios": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Jalios.png",
       "meta": {
         "generator": "Jalios"
@@ -5431,9 +4339,7 @@
       "website": "http://www.jalios.com"
     },
     "Java": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "cookies": {
         "JSESSIONID": ""
       },
@@ -5441,9 +4347,7 @@
       "website": "http://java.com"
     },
     "Java Servlet": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Powered-By": "Servlet(?:.([\\d.]+))?\\;version:\\1"
       },
@@ -5452,9 +4356,7 @@
       "website": "http://www.oracle.com/technetwork/java/index-jsp-135475.html"
     },
     "JavaScript Infovis Toolkit": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "JavaScript Infovis Toolkit.png",
       "js": {
         "$jit": "",
@@ -5464,9 +4366,7 @@
       "website": "https://philogb.github.io/jit/"
     },
     "JavaServer Faces": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Powered-By": "JSF(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -5475,9 +4375,7 @@
       "website": "http://javaserverfaces.java.net"
     },
     "JavaServer Pages": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Powered-By": "JSP(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -5486,9 +4384,7 @@
       "website": "http://www.oracle.com/technetwork/java/javaee/jsp/index.html"
     },
     "Jekyll": {
-      "cats": [
-        57
-      ],
+      "cats": [57],
       "cpe": "cpe:/a:jekyllrb:jekyll",
       "html": [
         "Powered by <a href=\"https?://jekyllrb\\.com\"[^>]*>Jekyll</",
@@ -5502,9 +4398,7 @@
       "website": "http://jekyllrb.com"
     },
     "Jenkins": {
-      "cats": [
-        44
-      ],
+      "cats": [44],
       "headers": {
         "X-Jenkins": "([\\d.]+)\\;version:\\1"
       },
@@ -5518,9 +4412,7 @@
       "website": "https://jenkins.io/"
     },
     "Jetshop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<(?:div|aside) id=\"jetshop-branding\">",
       "icon": "Jetshop.png",
       "js": {
@@ -5529,9 +4421,7 @@
       "website": "http://jetshop.se"
     },
     "Jetty": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Jetty(?:\\(([\\d\\.]*\\d+))?\\;version:\\1"
       },
@@ -5540,9 +4430,7 @@
       "website": "http://www.eclipse.org/jetty"
     },
     "Jimdo": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Jimdo-Instance": "",
         "X-Jimdo-Wid": ""
@@ -5556,10 +4444,7 @@
       "website": "https://www.jimdo.com"
     },
     "Jirafe": {
-      "cats": [
-        10,
-        32
-      ],
+      "cats": [10, 32],
       "icon": "Jirafe.png",
       "js": {
         "jirafe": ""
@@ -5568,9 +4453,7 @@
       "website": "https://docs.jirafe.com"
     },
     "Jive": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "headers": {
         "X-JIVE-USER-ID": "",
         "X-JSL": "",
@@ -5582,9 +4465,7 @@
       "website": "http://www.jivesoftware.com"
     },
     "JobberBase": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "JobberBase.png",
       "implies": "PHP",
       "js": {
@@ -5596,9 +4477,7 @@
       "website": "http://www.jobberbase.com"
     },
     "Joomla": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:joomla:joomla",
       "headers": {
         "X-Content-Encoded-By": "Joomla! ([\\d.]+)\\;version:\\1"
@@ -5617,9 +4496,7 @@
       "website": "https://www.joomla.org"
     },
     "K2": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "<!--(?: JoomlaWorks \"K2\"| Start K2)",
       "icon": "K2.png",
       "implies": "Joomla",
@@ -5629,9 +4506,7 @@
       "website": "https://getk2.org"
     },
     "KISSmetrics": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "KISSmetrics.png",
       "js": {
         "KM_COOKIE_DOMAIN": ""
@@ -5639,9 +4514,7 @@
       "website": "https://www.kissmetrics.com"
     },
     "Kajabi": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "_kjb_session": ""
       },
@@ -5652,10 +4525,7 @@
       "website": "https://newkajabi.com"
     },
     "Kampyle": {
-      "cats": [
-        10,
-        13
-      ],
+      "cats": [10, 13],
       "cookies": {
         "k_visit": ""
       },
@@ -5669,9 +4539,7 @@
       "website": "http://www.kampyle.com"
     },
     "Kamva": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Kamva.svg",
       "js": {
         "Kamva": ""
@@ -5683,10 +4551,7 @@
       "website": "https://kamva.ir"
     },
     "Kemal": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "headers": {
         "X-Powered-By": "Kemal"
       },
@@ -5694,9 +4559,7 @@
       "website": "http://kemalcr.com"
     },
     "Kendo UI": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": "<link[^>]*\\s+href=[^>]*styles/kendo\\.common(?:\\.min)?\\.css[^>]*/>",
       "icon": "Kendo UI.png",
       "implies": "jQuery",
@@ -5707,9 +4570,7 @@
       "website": "https://www.telerik.com/kendo-ui"
     },
     "Kentico CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "CMSPreferredCulture": ""
       },
@@ -5721,22 +4582,16 @@
       "website": "http://www.kentico.com"
     },
     "Kestrel": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "^Kestrel"
       },
-      "implies": [
-        "Microsoft ASP.NET"
-      ],
+      "implies": ["Microsoft ASP.NET"],
       "icon": "kestrel.svg",
       "website": "https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel"
     },
     "KeyCDN": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Server": "^keycdn-engine$"
       },
@@ -5744,10 +4599,7 @@
       "website": "http://www.keycdn.com"
     },
     "Kibana": {
-      "cats": [
-        29,
-        25
-      ],
+      "cats": [29, 25],
       "cpe": "cpe:/a:elasticsearch:kibana",
       "headers": {
         "kbn-name": "kibana",
@@ -5760,9 +4612,7 @@
       "website": "http://www.elastic.co/products/kibana"
     },
     "KineticJS": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "KineticJS.png",
       "js": {
         "Kinetic": "",
@@ -5772,11 +4622,7 @@
       "website": "https://github.com/ericdrowell/KineticJS/"
     },
     "Klarna Checkout": {
-      "cats": [
-        41,
-        6,
-        5
-      ],
+      "cats": [41, 6, 5],
       "icon": "Klarna.svg",
       "js": {
         "_klarnaCheckout": ""
@@ -5784,9 +4630,7 @@
       "website": "https://www.klarna.com/international/"
     },
     "Knockout.js": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Knockout.js.png",
       "js": {
         "ko.version": "^(.+)$\\;version:\\1"
@@ -5794,10 +4638,7 @@
       "website": "http://knockoutjs.com"
     },
     "Koa": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "headers": {
         "X-Powered-By": "^koa$"
       },
@@ -5806,10 +4647,7 @@
       "website": "http://koajs.com"
     },
     "Koala Framework": {
-      "cats": [
-        1,
-        18
-      ],
+      "cats": [1, 18],
       "html": "<!--[^>]+This website is powered by Koala Web Framework CMS",
       "icon": "Koala Framework.png",
       "implies": "PHP",
@@ -5819,9 +4657,7 @@
       "website": "http://koala-framework.org"
     },
     "KobiMaster": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Kobimaster.png",
       "implies": "Microsoft ASP.NET",
       "js": {
@@ -5831,9 +4667,7 @@
       "website": "https://www.kobimaster.com.tr"
     },
     "Koha": {
-      "cats": [
-        50
-      ],
+      "cats": [50],
       "cpe": "cpe:/a:koha:koha",
       "html": [
         "<input name=\"koha_login_context\" value=\"intranet\" type=\"hidden\">",
@@ -5850,9 +4684,7 @@
       "website": "https://koha-community.org/"
     },
     "Kohana": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "kohanasession": ""
       },
@@ -5865,9 +4697,7 @@
       "website": "http://kohanaframework.org"
     },
     "Koken": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "koken_referrer": ""
       },
@@ -5876,10 +4706,7 @@
         "<!--\\s+KOKEN DEBUGGING"
       ],
       "icon": "Koken.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "meta": {
         "generator": "Koken ([\\d.]+)\\;version:\\1"
       },
@@ -5887,9 +4714,7 @@
       "website": "http://koken.me"
     },
     "Kolibri CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "Kolibri"
       },
@@ -5899,9 +4724,7 @@
       "website": "http://alias.io"
     },
     "Komodo CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Komodo CMS.png",
       "implies": "PHP",
       "meta": {
@@ -5910,17 +4733,13 @@
       "website": "http://www.komodocms.com"
     },
     "Kontaktify": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Kontaktify.png",
       "script": "//(?:www\\.)?kontaktify\\.com/embed\\.js",
       "website": "https://www.kontaktify.com"
     },
     "Koobi": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<!--[^K>-]+Koobi ([a-z\\d.]+)\\;version:\\1",
       "icon": "Koobi.png",
       "meta": {
@@ -5929,9 +4748,7 @@
       "website": "http://dream4.de/cms"
     },
     "Kooboo CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-KoobooCMS-Version": "^(.+)$\\;version:\\1"
       },
@@ -5941,26 +4758,20 @@
       "website": "http://kooboo.com"
     },
     "Kotisivukone": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Kotisivukone.png",
       "script": "kotisivukone(?:\\.min)?\\.js",
       "website": "http://www.kotisivukone.fi"
     },
     "Kubernetes Dashboard": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "cpe": "cpe:/a:kubernetes:kubernetes",
       "html": "<html ng-app=\"kubernetesDashboard\">",
       "icon": "Kubernetes.svg",
       "website": "https://kubernetes.io/"
     },
     "LEPTON": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:lepton-cms:lepton",
       "icon": "LEPTON.png",
       "implies": "PHP",
@@ -5970,9 +4781,7 @@
       "website": "http://www.lepton-cms.org"
     },
     "LabVIEW": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:ni:labview",
       "headers": {
         "Server": "LabVIEW(?:/([\\d\\.]+))?\\;version:\\1"
@@ -5981,9 +4790,7 @@
       "website": "http://ni.com/labview"
     },
     "Laravel": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "laravel_session": ""
       },
@@ -5996,9 +4803,7 @@
       "website": "https://laravel.com"
     },
     "Laterpay": {
-      "cats": [
-        41
-      ],
+      "cats": [41],
       "icon": "laterpay.png",
       "meta": {
         "laterpay:connector:callbacks:on_user_has_access": "deobfuscateText"
@@ -6007,16 +4812,12 @@
       "website": "https://www.laterpay.net/"
     },
     "Lazy.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "script": "lazy(?:\\.browser)?(?:\\.min)?\\.js",
       "website": "http://danieltao.com/lazy.js"
     },
     "Leaflet": {
-      "cats": [
-        35
-      ],
+      "cats": [35],
       "icon": "Leaflet.png",
       "js": {
         "L.DistanceGrid": "",
@@ -6027,17 +4828,13 @@
       "website": "http://leafletjs.com"
     },
     "Less": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "<link[^>]+ rel=\"stylesheet/less\"",
       "icon": "Less.png",
       "website": "http://lesscss.org"
     },
     "Liferay": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:liferay:liferay_portal",
       "headers": {
         "Liferay-Portal": "[a-z\\s]+([\\d.]+)\\;version:\\1"
@@ -6049,9 +4846,7 @@
       "website": "https://www.liferay.com"
     },
     "Lift": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cpe": "cpe:/a:liftweb:lift",
       "headers": {
         "X-Lift-Version": "(.+)\\;version:\\1"
@@ -6061,9 +4856,7 @@
       "website": "http://liftweb.net"
     },
     "LightMon Engine": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "lm_online": ""
       },
@@ -6076,9 +4869,7 @@
       "website": "http://lightmon.ru"
     },
     "Lightbox": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "cpe": "cpe:/a:lightbox_photo_gallery_project:lightbox_photo_gallery",
       "html": "<link [^>]*href=\"[^\"]+lightbox(?:\\.min)?\\.css",
       "icon": "Lightbox.png",
@@ -6086,9 +4877,7 @@
       "website": "http://lokeshdhakar.com/projects/lightbox2/"
     },
     "Lightspeed eCom": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<!-- \\[START\\] 'blocks/head\\.rain' -->",
       "icon": "Lightspeed.svg",
       "script": "http://assets\\.webshopapp\\.com",
@@ -6096,9 +4885,7 @@
       "website": "http://www.lightspeedhq.com/products/ecommerce/"
     },
     "Lighty": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "lighty_version": ""
       },
@@ -6107,9 +4894,7 @@
       "website": "https://gitlab.com/lighty/framework"
     },
     "LimeSurvey": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "cpe": "cpe:/a:limesurvey:limesurvey",
       "headers": {
         "generator": "LimeSurvey"
@@ -6118,9 +4903,7 @@
       "website": "http://limesurvey.org/"
     },
     "LinkSmart": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "LinkSmart.png",
       "js": {
         "LS_JSON": "",
@@ -6131,17 +4914,13 @@
       "website": "http://linksmart.com"
     },
     "Linkedin": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Linkedin.svg",
       "script": "//platform\\.linkedin\\.com/in\\.js",
       "website": "http://linkedin.com"
     },
     "Liquid Web": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "x-lw-cache": ""
       },
@@ -6149,9 +4928,7 @@
       "website": "https://www.liquidweb.com"
     },
     "List.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "List.js.png",
       "js": {
         "List": ""
@@ -6160,9 +4937,7 @@
       "website": "http://listjs.com"
     },
     "LiteSpeed": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:litespeedtech:litespeed_web_server",
       "headers": {
         "Server": "^LiteSpeed$"
@@ -6171,9 +4946,7 @@
       "website": "http://litespeedtech.com"
     },
     "Lithium": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "LithiumVisitor": ""
       },
@@ -6186,9 +4959,7 @@
       "website": "https://www.lithium.com"
     },
     "LiveAgent": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "LiveAgent.png",
       "js": {
         "LiveAgent": ""
@@ -6196,18 +4967,13 @@
       "website": "https://www.ladesk.com"
     },
     "LiveChat": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "LiveChat.png",
       "script": "cdn\\.livechatinc\\.com/.*tracking\\.js",
       "website": "http://livechatinc.com"
     },
     "LiveHelp": {
-      "cats": [
-        52,
-        53
-      ],
+      "cats": [52, 53],
       "icon": "LiveHelp.png",
       "js": {
         "LHready": ""
@@ -6215,25 +4981,19 @@
       "website": "http://www.livehelp.it"
     },
     "LiveJournal": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "icon": "LiveJournal.png",
       "url": "\\.livejournal\\.com",
       "website": "http://www.livejournal.com"
     },
     "LivePerson": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "LivePerson.png",
       "script": "^https?://lptag\\.liveperson\\.net/tag/tag\\.js",
       "website": "https://www.liveperson.com/"
     },
     "LiveStreet CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "LiveStreet CMS"
       },
@@ -6245,9 +5005,7 @@
       "website": "http://livestreetcms.com"
     },
     "Livefyre": {
-      "cats": [
-        15
-      ],
+      "cats": [15],
       "html": "<[^>]+(?:id|class)=\"livefyre",
       "icon": "Livefyre.png",
       "js": {
@@ -6260,9 +5018,7 @@
       "website": "http://livefyre.com"
     },
     "Liveinternet": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "html": [
         "<script[^<>]*>[^]{0,128}?src\\s*=\\s*['\"]//counter\\.yadro\\.ru/hit(?:;\\S+)?\\?(?:t\\d+\\.\\d+;)?r",
         "<!--LiveInternet counter-->",
@@ -6274,33 +5030,21 @@
       "website": "http://liveinternet.ru/rating/"
     },
     "LocalFocus": {
-      "cats": [
-        61
-      ],
+      "cats": [61],
       "html": "<iframe[^>]+localfocus",
       "icon": "LocalFocus.png",
-      "implies": [
-        "Angular",
-        "D3"
-      ],
+      "implies": ["Angular", "D3"],
       "website": "https://www.localfocus.nl/en/"
     },
     "Locomotive": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<link[^>]*/sites/[a-z\\d]{24}/theme/stylesheets",
       "icon": "Locomotive.png",
-      "implies": [
-        "Ruby on Rails",
-        "MongoDB"
-      ],
+      "implies": ["Ruby on Rails", "MongoDB"],
       "website": "http://www.locomotivecms.com"
     },
     "Lodash": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "cpe": "cpe:/a:lodash:lodash",
       "excludes": "Underscore.js",
       "icon": "Lo-dash.png",
@@ -6312,10 +5056,7 @@
       "website": "http://www.lodash.com"
     },
     "Logitech Media Server": {
-      "cats": [
-        22,
-        38
-      ],
+      "cats": [22, 38],
       "headers": {
         "Server": "Logitech Media Server(?: \\(([\\d\\.]+))?\\;version:\\1"
       },
@@ -6323,9 +5064,7 @@
       "website": "http://www.mysqueezebox.com"
     },
     "Lotus Domino": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:ibm:lotus_domino",
       "headers": {
         "Server": "Lotus-Domino"
@@ -6335,17 +5074,13 @@
       "website": "http://www-01.ibm.com/software/lotus/products/domino"
     },
     "LOU": {
-      "cats": [
-        58
-      ],
+      "cats": [58],
       "icon": "LOU.png",
       "script": "cdn\\.louassist\\.com*",
       "website": "https://www.louassist.com"
     },
     "Lua": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "cpe": "cpe:/a:lua:lua",
       "headers": {
         "X-Powered-By": "\\bLua(?: ([\\d.]+))?\\;version:\\1"
@@ -6354,19 +5089,14 @@
       "website": "http://www.lua.org"
     },
     "Lucene": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "cpe": "cpe:/a:apache:lucene",
       "icon": "Lucene.png",
       "implies": "Java",
       "website": "http://lucene.apache.org/core/"
     },
     "Luigi’s Box": {
-      "cats": [
-        10,
-        29
-      ],
+      "cats": [10, 29],
       "icon": "Luigisbox.svg",
       "js": {
         "Luigis": ""
@@ -6374,9 +5104,7 @@
       "website": "https://www.luigisbox.com"
     },
     "MODX": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:modx:modx_revolution",
       "headers": {
         "X-Powered-By": "^MODX"
@@ -6399,10 +5127,7 @@
       "website": "http://modx.com"
     },
     "MYPAGE Platform": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "cookies": {
         "mypage_session": ""
       },
@@ -6414,10 +5139,7 @@
       "website": "https://www.mypage.vn"
     },
     "Botble CMS": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "cookies": {
         "botble_session": ""
       },
@@ -6429,9 +5151,7 @@
       "website": "https://botble.com"
     },
     "MadAdsMedia": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "MadAdsMedia.png",
       "js": {
         "setMIframe": "",
@@ -6441,9 +5161,7 @@
       "website": "http://madadsmedia.com"
     },
     "Magento": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "frontend": "\\;confidence:50"
       },
@@ -6454,10 +5172,7 @@
         "<script type=\"text/x-magento-init\">"
       ],
       "icon": "Magento.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "js": {
         "Mage": "",
         "VarienForm": ""
@@ -6470,9 +5185,7 @@
       "website": "https://magento.com"
     },
     "MailChimp": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "cpe": "cpe:/a:thinkshout:mailchimp",
       "html": [
         "<form [^>]*data-mailchimp-url",
@@ -6489,9 +5202,7 @@
       "website": "http://mailchimp.com"
     },
     "MakeShopKorea": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "MakeShopKorea.png",
       "js": {
         "Makeshop": "",
@@ -6500,9 +5211,7 @@
       "website": "https://www.makeshop.co.kr"
     },
     "Mambo": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "excludes": "Joomla",
       "icon": "Mambo.png",
       "meta": {
@@ -6511,9 +5220,7 @@
       "website": "http://mambo-foundation.org"
     },
     "MantisBT": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "cpe": "cpe:/a:mantisbt:mantisbt",
       "html": "<img[^>]+ alt=\"Powered by Mantis Bugtracker",
       "icon": "MantisBT.png",
@@ -6521,30 +5228,21 @@
       "website": "http://www.mantisbt.org"
     },
     "ManyContacts": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "ManyContacts.png",
       "script": "\\/assets\\/js\\/manycontacts\\.min\\.js",
       "website": "http://www.manycontacts.com"
     },
     "MariaDB": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "cpe": "cpe:/a:mariadb_project:mariadb",
       "icon": "mariadb.svg",
       "website": "https://mariadb.org"
     },
     "Marionette.js": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Marionette.js.svg",
-      "implies": [
-        "Underscore.js",
-        "Backbone.js"
-      ],
+      "implies": ["Underscore.js", "Backbone.js"],
       "js": {
         "Marionette": "",
         "Marionette.VERSION": "^(.+)$\\;version:\\1"
@@ -6553,9 +5251,7 @@
       "website": "https://marionettejs.com"
     },
     "Marked": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "cpe": "cpe:/a:marked_project:marked",
       "icon": "marked.svg",
       "js": {
@@ -6565,9 +5261,7 @@
       "website": "https://marked.js.org"
     },
     "Marketo": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "icon": "Marketo.png",
       "js": {
         "Munchkin": ""
@@ -6576,9 +5270,7 @@
       "website": "https://www.marketo.com"
     },
     "Material Design Lite": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": "<link[^>]* href=\"[^\"]*material(?:\\.[\\w]+-[\\w]+)?(?:\\.min)?\\.css",
       "icon": "Material Design Lite.png",
       "js": {
@@ -6588,18 +5280,14 @@
       "website": "https://getmdl.io"
     },
     "Materialize CSS": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": "<link[^>]* href=\"[^\"]*materialize(?:\\.min)?\\.css",
       "icon": "Materialize CSS.png",
       "script": "materialize(?:\\.min)?\\.js",
       "website": "http://materializecss.com"
     },
     "MathJax": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "MathJax.png",
       "js": {
         "MathJax": "",
@@ -6609,9 +5297,7 @@
       "website": "https://www.mathjax.org"
     },
     "Matomo": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "cookies": {
         "PIWIK_SESSID": ""
       },
@@ -6631,16 +5317,11 @@
       "website": "https://matomo.org"
     },
     "Mattermost": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "cpe": "cpe:/a:jenkins:mattermost",
       "html": "<noscript> To use Mattermost, please enable JavaScript\\. </noscript>",
       "icon": "mattermost.png",
-      "implies": [
-        "Go",
-        "React"
-      ],
+      "implies": ["Go", "React"],
       "js": {
         "mm_config": "",
         "mm_current_user_id": "",
@@ -6650,9 +5331,7 @@
       "website": "https://about.mattermost.com"
     },
     "Mautic": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "cpe": "cpe:/a:mautic:mautic",
       "icon": "mautic.svg",
       "js": {
@@ -6662,9 +5341,7 @@
       "website": "https://www.mautic.org/"
     },
     "MaxCDN": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Server": "^NetDNA",
         "X-CDN-Forward": "^maxcdn$"
@@ -6673,9 +5350,7 @@
       "website": "http://www.maxcdn.com"
     },
     "MaxSite CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "MaxSite CMS.png",
       "implies": "PHP",
       "meta": {
@@ -6684,24 +5359,16 @@
       "website": "http://max-3000.com"
     },
     "Mean.io": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "headers": {
         "X-Powered-CMS": "Mean\\.io"
       },
       "icon": "Mean.io.png",
-      "implies": [
-        "MongoDB",
-        "Express",
-        "Angular"
-      ],
+      "implies": ["MongoDB", "Express", "Angular"],
       "website": "http://mean.io"
     },
     "MediaElement.js": {
-      "cats": [
-        14
-      ],
+      "cats": [14],
       "icon": "MediaElement.js.png",
       "js": {
         "mejs": "",
@@ -6710,9 +5377,7 @@
       "website": "http://www.mediaelementjs.com"
     },
     "MediaTomb": {
-      "cats": [
-        38
-      ],
+      "cats": [38],
       "headers": {
         "Server": "MediaTomb(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -6720,9 +5385,7 @@
       "website": "http://mediatomb.cc"
     },
     "MediaWiki": {
-      "cats": [
-        8
-      ],
+      "cats": [8],
       "cpe": "cpe:/a:mediawiki:mediawiki",
       "html": [
         "<body[^>]+class=\"mediawiki\"",
@@ -6740,9 +5403,7 @@
       "website": "https://www.mediawiki.org"
     },
     "Medium": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "headers": {
         "X-Powered-By": "^Medium$"
       },
@@ -6753,18 +5414,13 @@
       "website": "https://medium.com"
     },
     "Meebo": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "html": "(?:<iframe id=\"meebo-iframe\"|Meebo\\('domReady'\\))",
       "icon": "Meebo.png",
       "website": "http://www.meebo.com"
     },
     "Melis CMS V2": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "html": "<!-- Rendered with Melis CMS V2",
       "icon": "meliscmsv2.png",
       "meta": {
@@ -6773,10 +5429,7 @@
       "website": "http://www.melistechnology.com/"
     },
     "MemberStack": {
-      "cats": [
-        6,
-        47
-      ],
+      "cats": [6, 47],
       "icon": "MemberStack.png",
       "cookies": {
         "memberstack": ""
@@ -6789,9 +5442,7 @@
       "website": "https://www.memberstack.io"
     },
     "Mermaid": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "html": "<div [^>]*class=[\"']mermaid[\"']>\\;confidence:90",
       "js": {
         "mermaid": ""
@@ -6800,16 +5451,10 @@
       "website": "https://mermaidjs.github.io/"
     },
     "Meteor": {
-      "cats": [
-        12,
-        18
-      ],
+      "cats": [12, 18],
       "html": "<link[^>]+__meteor-css__",
       "icon": "Meteor.png",
-      "implies": [
-        "MongoDB",
-        "Node.js"
-      ],
+      "implies": ["MongoDB", "Node.js"],
       "js": {
         "Meteor": "",
         "Meteor.release": "^METEOR@([\\d.]+)\\;version:\\1"
@@ -6817,9 +5462,7 @@
       "website": "https://www.meteor.com"
     },
     "Methode": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<!-- Methode uuid: \"[a-f\\d]+\" ?-->",
       "icon": "Methode.png",
       "meta": {
@@ -6832,9 +5475,7 @@
       "website": "https://www.eidosmedia.com/"
     },
     "Microsoft ASP.NET": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "ASP.NET_SessionId": "",
         "ASPSESSION": ""
@@ -6851,9 +5492,7 @@
       "website": "https://www.asp.net"
     },
     "Microsoft Excel": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "cpe": "cpe:/a:microsoft:excel",
       "html": "(?:<html [^>]*xmlns:w=\"urn:schemas-microsoft-com:office:excel\"|<!--\\s*(?:START|END) OF OUTPUT FROM EXCEL PUBLISH AS WEB PAGE WIZARD\\s*-->|<div [^>]*x:publishsource=\"?Excel\"?)",
       "icon": "Microsoft Excel.svg",
@@ -6864,9 +5503,7 @@
       "website": "https://office.microsoft.com/excel"
     },
     "Microsoft HTTPAPI": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Microsoft-HTTPAPI(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -6874,9 +5511,7 @@
       "website": "http://microsoft.com"
     },
     "Microsoft PowerPoint": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "cpe": "cpe:/a:microsoft:powerpoint",
       "html": "(?:<html [^>]*xmlns:w=\"urn:schemas-microsoft-com:office:powerpoint\"|<link rel=\"?Presentation-XML\"? href=\"?[^\"]+\\.xml\"?>|<o:PresentationFormat>[^<]+</o:PresentationFormat>[^!]+<o:Slides>\\d+</o:Slides>(?:[^!]+<o:Version>([\\d.]+)</o:Version>)?)\\;version:\\1",
       "icon": "Microsoft PowerPoint.svg",
@@ -6887,9 +5522,7 @@
       "website": "https://office.microsoft.com/powerpoint"
     },
     "Microsoft Publisher": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "cpe": "cpe:/a:microsoft:publisher",
       "html": "(?:<html [^>]*xmlns:w=\"urn:schemas-microsoft-com:office:publisher\"|<!--[if pub]><xml>)",
       "icon": "Microsoft Publisher.svg",
@@ -6900,9 +5533,7 @@
       "website": "https://office.microsoft.com/publisher"
     },
     "Microsoft SharePoint": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:microsoft:sharepoint_server",
       "headers": {
         "MicrosoftSharePointTeamServices": "^(.+)$\\;version:\\1",
@@ -6921,9 +5552,7 @@
       "website": "https://sharepoint.microsoft.com"
     },
     "Microsoft Word": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "cpe": "cpe:/a:microsoft:word",
       "html": "(?:<html [^>]*xmlns:w=\"urn:schemas-microsoft-com:office:word\"|<w:WordDocument>|<div [^>]*class=\"?WordSection1[\" >]|<style[^>]*>[^>]*@page WordSection1)",
       "icon": "Microsoft Word.svg",
@@ -6934,9 +5563,7 @@
       "website": "https://office.microsoft.com/word"
     },
     "Mietshop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<a href=\"https://ssl\\.mietshop\\.d",
       "icon": "mietshop.png",
       "meta": {
@@ -6945,46 +5572,32 @@
       "website": "http://www.mietshop.de/"
     },
     "Milligram": {
-      "cats": [
-        66
-      ],
-      "html": [
-        "<link[^>]+?href=\"[^\"]+milligram(?:\\.min)?\\.css"
-      ],
+      "cats": [66],
+      "html": ["<link[^>]+?href=\"[^\"]+milligram(?:\\.min)?\\.css"],
       "icon": "Milligram.png",
       "website": "https://milligram.io"
     },
     "Minero.cc": {
-      "cats": [
-        56
-      ],
-      "script": [
-        "//minero\\.cc/lib/minero(?:-miner|-hidden)?\\.min\\.js"
-      ],
+      "cats": [56],
+      "script": ["//minero\\.cc/lib/minero(?:-miner|-hidden)?\\.min\\.js"],
       "website": "http://minero.cc/"
     },
     "MiniBB": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "cpe": "cpe:/a:minibb:minibb",
       "html": "<a href=\"[^\"]+minibb[^<]+</a>[^<]+\\n<!--End of copyright link",
       "icon": "MiniBB.png",
       "website": "http://www.minibb.com"
     },
     "MiniServ": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "MiniServ\\/?([\\d\\.]+)?\\;version:\\1"
       },
       "website": "http://sourceforge.net/projects/miniserv"
     },
     "Mint": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Mint.png",
       "js": {
         "Mint": ""
@@ -6993,17 +5606,13 @@
       "website": "https://haveamint.com"
     },
     "Mithril": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Mithril.svg",
       "script": "mithril/\\?js",
       "website": "https://mithril.js.org"
     },
     "Mixpanel": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Mixpanel.png",
       "js": {
         "mixpanel": ""
@@ -7012,9 +5621,7 @@
       "website": "https://mixpanel.com"
     },
     "MkDocs": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "icon": "mkdocs.png",
       "meta": {
         "generator": "^mkdocs-([\\d.]+)\\;version:\\1"
@@ -7022,9 +5629,7 @@
       "website": "http://www.mkdocs.org/"
     },
     "Mobify": {
-      "cats": [
-        26
-      ],
+      "cats": [26],
       "icon": "Mobify.png",
       "js": {
         "Mobify": ""
@@ -7033,9 +5638,7 @@
       "website": "https://www.mobify.com"
     },
     "Mobirise": {
-      "cats": [
-        51
-      ],
+      "cats": [51],
       "html": [
         "<!-- Site made with Mobirise Website Builder v([\\d.]+)\\;version:\\1"
       ],
@@ -7046,9 +5649,7 @@
       "website": "https://mobirise.com"
     },
     "MobX": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "MobX.svg",
       "js": {
         "__mobxGlobal": "",
@@ -7059,9 +5660,7 @@
       "website": "https://mobx.js.org"
     },
     "MochiKit": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "MochiKit.png",
       "js": {
         "MochiKit": "",
@@ -7071,9 +5670,7 @@
       "website": "https://mochi.github.io/mochikit/"
     },
     "MochiWeb": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:mochiweb_project:mochiweb",
       "headers": {
         "Server": "MochiWeb(?:/([\\d.]+))?\\;version:\\1"
@@ -7081,9 +5678,7 @@
       "website": "https://github.com/mochi/mochiweb"
     },
     "Modernizr": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Modernizr.svg",
       "js": {
         "Modernizr._version": "^(.+)$\\;version:\\1"
@@ -7094,9 +5689,7 @@
       "website": "https://modernizr.com"
     },
     "Modified": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "modified.png",
       "meta": {
         "generator": "\\(c\\) by modified eCommerce Shopsoftware ------ http://www\\.modified-shop\\.org"
@@ -7104,10 +5697,7 @@
       "website": "http://www.modified-shop.org/"
     },
     "Moguta.CMS": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "html": "<link[^>]+href=[\"'][^\"]+mg-(?:core|plugins|templates)/",
       "script": "mg-(?:core|plugins|templates)/",
       "icon": "Moguta.CMS.png",
@@ -7115,9 +5705,7 @@
       "website": "https://moguta.ru"
     },
     "MoinMoin": {
-      "cats": [
-        8
-      ],
+      "cats": [8],
       "cookies": {
         "MOIN_SESSION": ""
       },
@@ -7131,9 +5719,7 @@
       "website": "https://moinmo.in"
     },
     "Mojolicious": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "server": "^mojolicious",
         "x-powered-by": "mojolicious"
@@ -7143,9 +5729,7 @@
       "website": "http://mojolicio.us"
     },
     "Mollom": {
-      "cats": [
-        16
-      ],
+      "cats": [16],
       "cpe": "cpe:/a:acquia:mollom",
       "html": "<img[^>]+\\.mollom\\.com",
       "icon": "Mollom.png",
@@ -7153,18 +5737,14 @@
       "website": "http://mollom.com"
     },
     "Moment Timezone": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Moment.js.svg",
       "implies": "Moment.js",
       "script": "moment-timezone(?:-data)?(?:\\.min)?\\.js",
       "website": "http://momentjs.com/timezone/"
     },
     "Moment.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Moment.js.svg",
       "js": {
         "moment": "",
@@ -7174,9 +5754,7 @@
       "website": "https://momentjs.com"
     },
     "Mondo Media": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Mondo Media.png",
       "meta": {
         "generator": "Mondo Shop"
@@ -7184,25 +5762,19 @@
       "website": "http://mondo-media.de"
     },
     "Monerominer": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "html": "<iframe[^>]+src=[\\'\"]https?://monerominer\\.rocks/miner\\.php\\?siteid=",
       "icon": "monerominer.png",
       "website": "https://monerominer.rocks/"
     },
     "MongoDB": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "cpe": "cpe:/a:mongodb:mongodb",
       "icon": "MongoDB.png",
       "website": "http://www.mongodb.org"
     },
     "Mongrel": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:zed_shaw:mongrel",
       "headers": {
         "Server": "Mongrel"
@@ -7212,9 +5784,7 @@
       "website": "http://mongrel2.org"
     },
     "Monkey HTTP Server": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Monkey/?([\\d.]+)?\\;version:\\1"
       },
@@ -7222,9 +5792,7 @@
       "website": "http://monkey-project.com"
     },
     "Mono": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cpe": "cpe:/a:mono:mono",
       "headers": {
         "X-Powered-By": "Mono"
@@ -7233,9 +5801,7 @@
       "website": "http://mono-project.com"
     },
     "Mono.net": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Mono.net.png",
       "implies": "Matomo",
       "js": {
@@ -7245,9 +5811,7 @@
       "website": "https://www.mono.net/en"
     },
     "MooTools": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "MooTools.png",
       "js": {
         "MooTools": "",
@@ -7257,9 +5821,7 @@
       "website": "https://mootools.net"
     },
     "Moodle": {
-      "cats": [
-        21
-      ],
+      "cats": [21],
       "cookies": {
         "MOODLEID_": "",
         "MoodleSession": ""
@@ -7278,44 +5840,30 @@
       "website": "http://moodle.org"
     },
     "Moon": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "moon.svg",
       "script": "/moon(?:\\.min)?\\.js$",
       "website": "https://kbrsh.github.io/moon/"
     },
     "MotoCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<link [^>]*href=\"[^>]*\\/mt-content\\/[^>]*\\.css",
       "icon": "MotoCMS.svg",
-      "implies": [
-        "PHP",
-        "AngularJS",
-        "jQuery"
-      ],
+      "implies": ["PHP", "AngularJS", "jQuery"],
       "script": "/mt-includes/js/website(?:assets)?\\.(?:min)?\\.js",
       "website": "http://motocms.com"
     },
     "Mouse Flow": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "mouseflow.png",
       "js": {
         "_mfq": ""
       },
-      "script": [
-        "cdn\\.mouseflow\\.com"
-      ],
+      "script": ["cdn\\.mouseflow\\.com"],
       "website": "https://mouseflow.com/"
     },
     "Movable Type": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:sixapart:movable_type",
       "icon": "Movable Type.png",
       "meta": {
@@ -7324,9 +5872,7 @@
       "website": "http://movabletype.org"
     },
     "Mozard Suite": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Mozard Suite.png",
       "meta": {
         "author": "Mozard"
@@ -7335,10 +5881,7 @@
       "website": "http://mozard.nl"
     },
     "Mura CMS": {
-      "cats": [
-        1,
-        11
-      ],
+      "cats": [1, 11],
       "icon": "Mura CMS.png",
       "implies": "Adobe ColdFusion",
       "meta": {
@@ -7347,9 +5890,7 @@
       "website": "http://www.getmura.com"
     },
     "Mustache": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Mustache.png",
       "js": {
         "Mustache.version": "^(.+)$\\;version:\\1"
@@ -7358,41 +5899,30 @@
       "website": "https://mustache.github.io"
     },
     "MyBB": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "cpe": "cpe:/a:mybb:mybb",
       "html": "(?:<script [^>]+\\s+<!--\\s+lang\\.no_new_posts|<a[^>]* title=\"Powered By MyBB)",
       "icon": "MyBB.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "js": {
         "MyBB": ""
       },
       "website": "https://mybb.com"
     },
     "MyBlogLog": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "MyBlogLog.png",
       "script": "pub\\.mybloglog\\.com",
       "website": "http://www.mybloglog.com"
     },
     "MySQL": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "cpe": "cpe:/a:mysql:mysql",
       "icon": "MySQL.svg",
       "website": "http://mysql.com"
     },
     "Mynetcap": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Mynetcap.png",
       "meta": {
         "generator": "Mynetcap"
@@ -7400,9 +5930,7 @@
       "website": "http://www.netcap-creation.fr"
     },
     "NEO - Omnichannel Commerce Platform": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "powered": "jet-neo"
       },
@@ -7410,9 +5938,7 @@
       "website": "http://www.jetecommerce.com.br/"
     },
     "NVD3": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "html": "<link[^>]* href=[^>]+nv\\.d3(?:\\.min)?\\.css",
       "icon": "NVD3.png",
       "implies": "D3",
@@ -7424,17 +5950,13 @@
       "website": "http://nvd3.org"
     },
     "Navegg": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Navegg.png",
       "script": "tag\\.navdmp\\.com",
       "website": "https://www.navegg.com/"
     },
     "Neos CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "excludes": "TYPO3 CMS",
       "headers": {
         "X-Flow-Powered": "Neos/?(.+)?$\\;version:\\1"
@@ -7445,9 +5967,7 @@
       "website": "https://neos.io"
     },
     "Neos Flow": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "excludes": "TYPO3 CMS",
       "headers": {
         "X-Flow-Powered": "Flow/?(.+)?$\\;version:\\1"
@@ -7457,9 +5977,7 @@
       "website": "https://flow.neos.io"
     },
     "Nepso": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-CMS": "Nepso"
       },
@@ -7467,10 +5985,7 @@
       "website": "http://nepso.com"
     },
     "Netlify": {
-      "cats": [
-        62,
-        31
-      ],
+      "cats": [62, 31],
       "headers": {
         "X-NF-Request-ID": "",
         "Server": "^Netlify"
@@ -7480,9 +5995,7 @@
       "website": "https://www.netlify.com/"
     },
     "Neto": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Neto.svg",
       "js": {
         "NETO": ""
@@ -7491,9 +6004,7 @@
       "website": "https://www.neto.com.au"
     },
     "Netsuite": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "NS_VER": ""
       },
@@ -7501,9 +6012,7 @@
       "website": "http://netsuite.com"
     },
     "Nette Framework": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "nette-browser": ""
       },
@@ -7524,9 +6033,7 @@
       "website": "https://nette.org"
     },
     "New Relic": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "New Relic.png",
       "js": {
         "NREUM": "",
@@ -7535,45 +6042,31 @@
       "website": "https://newrelic.com"
     },
     "Next.js": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "cpe": "cpe:/a:zeit:next.js",
       "headers": {
         "x-powered-by": "^Next\\.js ?([0-9.]+)?\\;version:\\1"
       },
       "icon": "zeit.svg",
-      "implies": [
-        "React",
-        "webpack",
-        "Node.js"
-      ],
+      "implies": ["React", "webpack", "Node.js"],
       "js": {
         "__NEXT_DATA__": ""
       },
       "website": "https://github.com/zeit/next.js"
     },
     "NextGEN Gallery": {
-      "cats": [
-        7
-      ],
+      "cats": [7],
       "cpe": "cpe:/a:imagely:nextgen_gallery",
       "html": [
         "<!-- <meta name=\"NextGEN\" version=\"([\\d.]+)\" /> -->\\;version:\\1"
       ],
       "icon": "NextGEN Gallery.png",
-      "implies": [
-        "WordPress"
-      ],
+      "implies": ["WordPress"],
       "script": "/nextgen-gallery/js/",
       "website": "https://www.imagely.com/wordpress-gallery-plugin"
     },
     "Nginx": {
-      "cats": [
-        22,
-        64
-      ],
+      "cats": [22, 64],
       "cpe": "cpe:/a:nginx:nginx",
       "headers": {
         "Server": "nginx(?:/([\\d.]+))?\\;version:\\1",
@@ -7583,17 +6076,13 @@
       "website": "http://nginx.org/en"
     },
     "Node.js": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "cpe": "cpe:/a:nodejs:node.js",
       "icon": "node.js.png",
       "website": "http://nodejs.org"
     },
     "NodeBB": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "cpe": "cpe:/a:nodebb:nodebb",
       "headers": {
         "X-Powered-By": "^NodeBB$"
@@ -7604,9 +6093,7 @@
       "website": "https://nodebb.org"
     },
     "Now": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "server": "^now$",
         "x-now-trace": "",
@@ -7617,9 +6104,7 @@
       "website": "https://zeit.co/now"
     },
     "OWL Carousel": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "html": "<link [^>]*href=\"[^\"]+owl\\.carousel(?:\\.min)?\\.css",
       "icon": "OWL Carousel.png",
       "implies": "jQuery",
@@ -7627,9 +6112,7 @@
       "website": "https://owlcarousel2.github.io/OwlCarousel2/"
     },
     "OXID eShop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<!--[^-]*OXID eShop",
       "icon": "OXID eShop.png",
       "js": {
@@ -7642,9 +6125,7 @@
       "website": "https://en.oxid-esales.com/en/home.html"
     },
     "October CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "october_session=": ""
       },
@@ -7653,9 +6134,7 @@
       "website": "http://octobercms.com"
     },
     "Octopress": {
-      "cats": [
-        57
-      ],
+      "cats": [57],
       "html": "Powered by <a href=\"http://octopress\\.org\">",
       "icon": "octopress.png",
       "implies": "Jekyll",
@@ -7666,19 +6145,11 @@
       "website": "http://octopress.org"
     },
     "Odoo": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "cpe": "cpe:/a:odoo:odoo",
       "html": "<link[^>]* href=[^>]+/web/css/(?:web\\.assets_common/|website\\.assets_frontend/)\\;confidence:25",
       "icon": "Odoo.png",
-      "implies": [
-        "Python",
-        "PostgreSQL",
-        "Node.js",
-        "Less"
-      ],
+      "implies": ["Python", "PostgreSQL", "Node.js", "Less"],
       "meta": {
         "generator": "Odoo"
       },
@@ -7686,17 +6157,13 @@
       "website": "http://odoo.com"
     },
     "Olark": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "Olark.png",
       "script": "^https?:\\/\\/static\\.olark\\.com\\/jsclient\\/loader1\\.js",
       "website": "https://www.olark.com/"
     },
     "OneAPM": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "OneAPM.png",
       "js": {
         "BWEUM": ""
@@ -7704,9 +6171,7 @@
       "website": "http://www.oneapm.com"
     },
     "OneStat": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "OneStat.png",
       "js": {
         "OneStat_Pageview": ""
@@ -7714,9 +6179,7 @@
       "website": "http://www.onestat.com"
     },
     "Open AdStream": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Open AdStream.png",
       "js": {
         "OAS_AD": ""
@@ -7724,9 +6187,7 @@
       "website": "https://www.xaxis.com"
     },
     "Open Classifieds": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cpe": "cpe:/a:open-classifieds:open_classifieds",
       "icon": "Open Classifieds.png",
       "meta": {
@@ -7736,9 +6197,7 @@
       "website": "http://open-classifieds.com"
     },
     "Open Journal Systems": {
-      "cats": [
-        50
-      ],
+      "cats": [50],
       "cookies": {
         "OJSSID": ""
       },
@@ -7751,9 +6210,7 @@
       "website": "http://pkp.sfu.ca/ojs"
     },
     "Open Web Analytics": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "cpe": "cpe:/a:openwebanalytics:open_web_analytics",
       "html": "<!-- (?:Start|End) Open Web Analytics Tracker -->",
       "icon": "Open Web Analytics.png",
@@ -7765,9 +6222,7 @@
       "website": "http://www.openwebanalytics.com"
     },
     "Open eShop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Open eShop.png",
       "implies": "PHP",
       "meta": {
@@ -7777,18 +6232,14 @@
       "website": "http://open-eshop.com/"
     },
     "OpenBSD httpd": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "^OpenBSD httpd"
       },
       "website": "https://man.openbsd.org/httpd.8"
     },
     "OpenCart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "OCSESSID": ""
       },
@@ -7798,9 +6249,7 @@
       "website": "http://www.opencart.com"
     },
     "OpenCms": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:alkacon:opencms",
       "headers": {
         "Server": "OpenCms"
@@ -7812,9 +6261,7 @@
       "website": "http://www.opencms.org"
     },
     "OpenGSE": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "GSE"
       },
@@ -7823,9 +6270,7 @@
       "website": "http://code.google.com/p/opengse"
     },
     "OpenGrok": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "cookies": {
         "OpenGrok": ""
       },
@@ -7837,9 +6282,7 @@
       "website": "http://hub.opensolaris.org/bin/view/Project+opengrok/WebHome"
     },
     "OpenLayers": {
-      "cats": [
-        35
-      ],
+      "cats": [35],
       "icon": "OpenLayers.png",
       "js": {
         "OpenLayers.VERSION_NUMBER": "([\\d.]+)\\;version:\\1",
@@ -7849,9 +6292,7 @@
       "website": "https://openlayers.org"
     },
     "OpenNemas": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "OpenNemas"
       },
@@ -7862,23 +6303,16 @@
       "website": "http://www.opennemas.com"
     },
     "OpenResty": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "openresty(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "OpenResty.png",
-      "implies": [
-        "Nginx",
-        "Lua"
-      ],
+      "implies": ["Nginx", "Lua"],
       "website": "http://openresty.org"
     },
     "OpenSSL": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "cpe": "cpe:/a:openssl:openssl",
       "headers": {
         "Server": "OpenSSL(?:/([\\d.]+[a-z]?))?\\;version:\\1"
@@ -7887,18 +6321,14 @@
       "website": "http://openssl.org"
     },
     "OpenText Web Solutions": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<!--[^>]+published by Open Text Web Solutions",
       "icon": "OpenText Web Solutions.png",
       "implies": "Microsoft ASP.NET",
       "website": "http://websolutions.opentext.com"
     },
     "OpenUI5": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "OpenUI5.png",
       "js": {
         "sap.ui.version": "^(.+)$\\;version:\\1"
@@ -7907,9 +6337,7 @@
       "website": "http://openui5.org/"
     },
     "OpenX": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "cpe": "cpe:/a:openx:openx",
       "icon": "OpenX.png",
       "script": [
@@ -7919,9 +6347,7 @@
       "website": "http://openx.com"
     },
     "Optimizely": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Optimizely.png",
       "js": {
         "optimizely": ""
@@ -7930,9 +6356,7 @@
       "website": "https://www.optimizely.com"
     },
     "Oracle Application Server": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:oracle:application_server",
       "headers": {
         "Server": "Oracle[- ]Application[- ]Server(?: Containers for J2EE)?(?:[- ](\\d[\\da-z./]+))?\\;version:\\1"
@@ -7941,9 +6365,7 @@
       "website": "http://www.oracle.com/technetwork/middleware/ias/overview/index.html"
     },
     "Oracle Commerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cpe": "cpe:/a:oracle:commerce_platform",
       "headers": {
         "X-ATG-Version": "(?:ATGPlatform/([\\d.]+))?\\;version:\\1"
@@ -7953,9 +6375,7 @@
       "website": "http://www.oracle.com/applications/customer-experience/commerce/products/commerce-platform/index.html"
     },
     "Oracle Commerce Cloud": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "OracleCommerceCloud-Version": "^(.+)$\\;version:\\1"
       },
@@ -7964,9 +6384,7 @@
       "website": "http://cloud.oracle.com/commerce-cloud"
     },
     "Oracle Dynamic Monitoring Service": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "headers": {
         "x-oracle-dms-ecid": ""
       },
@@ -7974,9 +6392,7 @@
       "website": "http://oracle.com"
     },
     "Oracle HTTP Server": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:oracle:http_server",
       "headers": {
         "Server": "Oracle-HTTP-Server(?:/([\\d.]+))?\\;version:\\1"
@@ -7985,17 +6401,13 @@
       "website": "http://oracle.com"
     },
     "Oracle Recommendations On Demand": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Oracle.png",
       "script": "atgsvcs.+atgsvcs\\.js",
       "website": "http://www.oracle.com/us/products/applications/commerce/recommendations-on-demand/index.html"
     },
     "Oracle Web Cache": {
-      "cats": [
-        23
-      ],
+      "cats": [23],
       "cpe": "cpe:/a:oracle:web_cache",
       "headers": {
         "Server": "Oracle(?:AS)?[- ]Web[- ]Cache(?:[- /]([\\da-z./]+))?\\;version:\\1"
@@ -8004,9 +6416,7 @@
       "website": "http://oracle.com"
     },
     "Orchard CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Orchard CMS.png",
       "implies": "Microsoft ASP.NET",
       "meta": {
@@ -8015,39 +6425,25 @@
       "website": "http://orchardproject.net"
     },
     "OrderOnline": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "OrderOnline.svg",
-      "implies": [
-        "PHP",
-        "MongoDB"
-      ],
+      "implies": ["PHP", "MongoDB"],
       "script": "^cdn\\.orderonline\\.id/$",
       "website": "https://orderonline.id"
     },
     "OroCommerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": [
         "<script [^>]+data-requiremodule=\"oro/",
         "<script [^>]+data-requiremodule=\"oroui/"
       ],
       "icon": "orocommerce.svg",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
-      "script": [
-        "oro\\.min\\.js\\?version=([\\d.]+)\\;version:\\1"
-      ],
+      "implies": ["PHP", "MySQL"],
+      "script": ["oro\\.min\\.js\\?version=([\\d.]+)\\;version:\\1"],
       "website": "https://oroinc.com"
     },
     "Outbrain": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Outbrain.png",
       "js": {
         "OB_releaseVer": "^(.+)$\\;version:\\1",
@@ -8057,9 +6453,7 @@
       "website": "https://www.outbrain.com"
     },
     "Outlook Web App": {
-      "cats": [
-        30
-      ],
+      "cats": [30],
       "html": "<link\\s[^>]*href=\"[^\"]*?([\\d.]+)/themes/resources/owafont\\.css\\;version:\\1",
       "icon": "Outlook.svg",
       "implies": "Microsoft ASP.NET",
@@ -8070,9 +6464,7 @@
       "website": "http://help.outlook.com"
     },
     "PANSITE": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "PANSITE.png",
       "meta": {
         "generator": "PANSITE"
@@ -8080,9 +6472,7 @@
       "website": "http://panvision.de/Produkte/Content_Management/index.asp"
     },
     "PDF.js": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "<\\/div>\\s*<!-- outerContainer -->\\s*<div\\s*id=\"printContainer\"><\\/div>",
       "icon": "PDF.js.svg",
       "js": {
@@ -8097,9 +6487,7 @@
       "website": "https://mozilla.github.io/pdf.js/"
     },
     "PHP": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "cookies": {
         "PHPSESSID": ""
       },
@@ -8113,25 +6501,18 @@
       "website": "http://php.net"
     },
     "PHP-Fusion": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:php-fusion:php-fusion",
       "html": "Powered by <a href=\"[^>]+php-fusion",
       "headers": {
         "X-Powered-By": "PHP-Fusion (.+)$\\;version:\\1"
       },
       "icon": "PHP-Fusion.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "website": "https://www.php-fusion.co.uk"
     },
     "PHP-Nuke": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:phpnuke:php-nuke",
       "html": "<[^>]+Powered by PHP-Nuke",
       "icon": "PHP-Nuke.png",
@@ -8142,23 +6523,17 @@
       "website": "http://phpnuke.org"
     },
     "PHPDebugBar": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "icon": "phpdebugbar.png",
       "js": {
         "PhpDebugBar": "",
         "phpdebugbar": ""
       },
-      "script": [
-        "debugbar.*\\.js"
-      ],
+      "script": ["debugbar.*\\.js"],
       "website": "http://phpdebugbar.com/"
     },
     "Cecil": {
-      "cats": [
-        57
-      ],
+      "cats": [57],
       "icon": "Cecil.png",
       "meta": {
         "generator": "^Cecil(?: ([0-9.]+))?$\\;version:\\1"
@@ -8166,9 +6541,7 @@
       "website": "https://cecil.app"
     },
     "Pagekit": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:pagekit:pagekit",
       "icon": "Pagekit.png",
       "meta": {
@@ -8177,9 +6550,7 @@
       "website": "http://pagekit.com"
     },
     "Pagevamp": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-ServedBy": "pagevamp"
       },
@@ -8190,25 +6561,17 @@
       "website": "https://www.pagevamp.com"
     },
     "Pantheon": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "x-pantheon-styx-hostname": "",
         "Server": "^Pantheon"
       },
-      "implies": [
-        "PHP",
-        "Nginx",
-        "MariaDB"
-      ],
+      "implies": ["PHP", "Nginx", "MariaDB"],
       "icon": "pantheon.svg",
       "website": "https://pantheon.io/"
     },
     "Paper.js": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "paperjs.png",
       "js": {
         "paper.version": "^(.+)$\\;version:\\1"
@@ -8216,9 +6579,7 @@
       "website": "http://paperjs.org/"
     },
     "Pardot": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "headers": {
         "X-Pardot-LB": "",
         "X-Pardot-Route": "",
@@ -8235,27 +6596,19 @@
       "website": "https://www.pardot.com"
     },
     "Pars Elecom Portal": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "Pars Elecom Portal"
       },
       "icon": "parselecom.png",
-      "implies": [
-        "Microsoft ASP.NET",
-        "IIS",
-        "Windows Server"
-      ],
+      "implies": ["Microsoft ASP.NET", "IIS", "Windows Server"],
       "meta": {
         "copyright": "Pars Elecom Portal"
       },
       "website": "http://parselecom.net"
     },
     "Parse.ly": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Parse.ly.png",
       "js": {
         "PARSELY": ""
@@ -8263,16 +6616,12 @@
       "website": "https://www.parse.ly"
     },
     "Paths.js": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "script": "paths(?:\\.min)?\\.js",
       "website": "https://github.com/andreaferretti/paths-js"
     },
     "PayPal": {
-      "cats": [
-        41
-      ],
+      "cats": [41],
       "cpe": "cpe:/a:paypal:paypal",
       "html": "<input[^>]+_s-xclick",
       "icon": "PayPal.svg",
@@ -8283,9 +6632,7 @@
       "website": "https://paypal.com"
     },
     "Pelican": {
-      "cats": [
-        57
-      ],
+      "cats": [57],
       "html": [
         "powered by <a href=\"[^>]+getpelican\\.com",
         "powered by <a href=\"https?://pelican\\.notmyidea\\.org"
@@ -8295,10 +6642,7 @@
       "website": "https://blog.getpelican.com/"
     },
     "PencilBlue": {
-      "cats": [
-        1,
-        11
-      ],
+      "cats": [1, 11],
       "headers": {
         "X-Powered-By": "PencilBlue"
       },
@@ -8307,24 +6651,18 @@
       "website": "http://pencilblue.org"
     },
     "Pendo": {
-      "cats": [
-        58
-      ],
+      "cats": [58],
       "icon": "Pendo.svg",
       "script": "cdn\\.pendo\\.io*\\.js",
       "website": "https://pendo.io"
     },
     "Percona": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "icon": "percona.svg",
       "website": "https://www.percona.com"
     },
     "Percussion": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<[^>]+class=\"perc-region\"",
       "icon": "Percussion.png",
       "meta": {
@@ -8333,9 +6671,7 @@
       "website": "http://percussion.com"
     },
     "Perl": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "cpe": "cpe:/a:perl:perl",
       "headers": {
         "Server": "\\bPerl\\b(?: ?/?v?([\\d.]+))?\\;version:\\1"
@@ -8344,25 +6680,18 @@
       "website": "http://perl.org"
     },
     "Phabricator": {
-      "cats": [
-        13,
-        47
-      ],
+      "cats": [13, 47],
       "cookies": {
         "phsid": ""
       },
       "html": "<[^>]+(?:class|id)=\"phabricator-",
       "icon": "Phabricator.png",
-      "implies": [
-        "PHP"
-      ],
+      "implies": ["PHP"],
       "script": "/phabricator/[a-f0-9]{8}/rsrc/js/phui/[a-z-]+\\.js$",
       "website": "http://phacility.com"
     },
     "Phaser": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Phaser.png",
       "js": {
         "Phaser": "",
@@ -8371,23 +6700,15 @@
       "website": "https://phaser.io"
     },
     "Phenomic": {
-      "cats": [
-        57
-      ],
-      "html": [
-        "<[^>]+id=\"phenomic(?:root)?\""
-      ],
+      "cats": [57],
+      "html": ["<[^>]+id=\"phenomic(?:root)?\""],
       "icon": "Phenomic.svg",
-      "implies": [
-        "React"
-      ],
+      "implies": ["React"],
       "script": "/phenomic\\.browser\\.[a-f0-9]+\\.js",
       "website": "https://phenomic.io/"
     },
     "Phusion Passenger": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:phusionpassenger:phusion_passenger",
       "headers": {
         "Server": "Phusion Passenger ([\\d.]+)\\;version:\\1",
@@ -8397,10 +6718,7 @@
       "website": "https://phusionpassenger.com"
     },
     "Pimcore": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "cpe": "cpe:/a:pimcore:pimcore",
       "headers": {
         "X-Powered-By": "^pimcore$"
@@ -8410,9 +6728,7 @@
       "website": "http://pimcore.org"
     },
     "Pingoteam": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Pingoteam.svg",
       "implies": "PHP",
       "meta": {
@@ -8421,17 +6737,13 @@
       "website": "https://www.pingoteam.ir/"
     },
     "Pinterest": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Pinterest.svg",
       "script": "//assets\\.pinterest\\.com/js/pinit\\.js",
       "website": "http://pinterest.com"
     },
     "Planet": {
-      "cats": [
-        49
-      ],
+      "cats": [49],
       "icon": "Planet.png",
       "meta": {
         "generator": "^Planet(?:/([\\d.]+))?\\;version:\\1"
@@ -8439,10 +6751,7 @@
       "website": "http://planetplanet.org"
     },
     "PlatformOS": {
-      "cats": [
-        1,
-        62
-      ],
+      "cats": [1, 62],
       "icon": "PlatformOS.svg",
       "headers": {
         "x-powered-by": "^platformOS$"
@@ -8450,9 +6759,7 @@
       "website": "https://www.platform-os.com"
     },
     "Platform.sh": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "icon": "platformsh.svg",
       "headers": {
         "x-platform-cluster": "",
@@ -8463,9 +6770,7 @@
       "website": "https://platform.sh"
     },
     "Play": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "PLAY_SESSION": ""
       },
@@ -8475,9 +6780,7 @@
       "website": "https://www.playframework.com"
     },
     "Plentymarkets": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Plentymarkets.png",
       "meta": {
         "generator": "plentymarkets"
@@ -8485,9 +6788,7 @@
       "website": "http://plentymarkets.eu"
     },
     "Plesk": {
-      "cats": [
-        9
-      ],
+      "cats": [9],
       "headers": {
         "X-Powered-By": "^Plesk(?:L|W)in",
         "X-Powered-By-Plesk": "^Plesk"
@@ -8497,9 +6798,7 @@
       "website": "https://www.plesk.com/"
     },
     "Pligg": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:pligg:pligg_cms",
       "html": "<span[^>]+id=\"xvotes-0",
       "icon": "Pligg.png",
@@ -8512,9 +6811,7 @@
       "website": "http://pligg.com"
     },
     "Plone": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:plone:plone",
       "icon": "Plone.png",
       "implies": "Python",
@@ -8524,9 +6821,7 @@
       "website": "http://plone.org"
     },
     "Plotly": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "Plotly.png",
       "implies": "D3",
       "js": {
@@ -8536,9 +6831,7 @@
       "website": "https://plot.ly/javascript/"
     },
     "Po.st": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Po.st.png",
       "js": {
         "pwidget_config": ""
@@ -8546,20 +6839,13 @@
       "website": "http://www.po.st/"
     },
     "Polyfill": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "polyfill.svg",
-      "script": [
-        "^https?://cdn\\.polyfill\\.io/",
-        "/polyfill\\.min\\.js"
-      ],
+      "script": ["^https?://cdn\\.polyfill\\.io/", "/polyfill\\.min\\.js"],
       "website": "https://polyfill.io"
     },
     "Polymer": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "html": "(?:<polymer-[^>]+|<link[^>]+rel=\"import\"[^>]+/polymer\\.html\")",
       "icon": "Polymer.png",
       "js": {
@@ -8569,10 +6855,7 @@
       "website": "http://polymer-project.org"
     },
     "Posterous": {
-      "cats": [
-        1,
-        11
-      ],
+      "cats": [1, 11],
       "html": "<div class=\"posterous",
       "icon": "Posterous.png",
       "js": {
@@ -8581,17 +6864,13 @@
       "website": "http://posterous.com"
     },
     "PostgreSQL": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "cpe": "cpe:/a:postgresql:postgresql",
       "icon": "PostgreSQL.png",
       "website": "http://www.postgresql.org/"
     },
     "Powergap": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": [
         "<a[^>]+title=\"POWERGAP",
         "<input type=\"hidden\" name=\"shopid\""
@@ -8600,24 +6879,17 @@
       "website": "http://powergap.de"
     },
     "Prebid": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Prebid.png",
       "js": {
         "PREBID_TIMEOUT": "",
         "pbjs": ""
       },
-      "script": [
-        "/prebid\\.js",
-        "adnxs\\.com/[^\"]*(?:prebid|/pb\\.js)"
-      ],
+      "script": ["/prebid\\.js", "adnxs\\.com/[^\"]*(?:prebid|/pb\\.js)"],
       "website": "http://prebid.org"
     },
     "Prefix-Free": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "Prefix-Free.png",
       "js": {
         "PrefixFree": ""
@@ -8626,9 +6898,7 @@
       "website": "https://leaverou.github.io/prefixfree/"
     },
     "PrestaShop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "PrestaShop": ""
       },
@@ -8642,10 +6912,7 @@
         "<!-- /Module Block [a-z ]+ -->"
       ],
       "icon": "PrestaShop.svg",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "js": {
         "freeProductTranslation": "\\;confidence:25",
         "priceDisplayMethod": "\\;confidence:25",
@@ -8657,9 +6924,7 @@
       "website": "http://www.prestashop.com"
     },
     "Prism": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "Prism.svg",
       "js": {
         "Prism": ""
@@ -8668,9 +6933,7 @@
       "website": "http://prismjs.com"
     },
     "Project Wonderful": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": "<div[^>]+id=\"pw_adbox_",
       "icon": "Project Wonderful.png",
       "js": {
@@ -8680,9 +6943,7 @@
       "website": "http://projectwonderful.com"
     },
     "ProjectPoi": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "icon": "ProjectPoi.png",
       "js": {
         "ProjectPoi": ""
@@ -8691,19 +6952,13 @@
       "website": "https://ppoi.org/"
     },
     "Projesoft": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "projesoft.png",
-      "script": [
-        "projesoft\\.js"
-      ],
+      "script": ["projesoft\\.js"],
       "website": "https://www.projesoft.com.tr"
     },
     "Prototype": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Prototype.png",
       "js": {
         "Prototype.Version": "^(.+)$\\;version:\\1"
@@ -8712,9 +6967,7 @@
       "website": "http://www.prototypejs.org"
     },
     "Protovis": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "js": {
         "protovis": ""
       },
@@ -8722,16 +6975,10 @@
       "website": "http://mbostock.github.io/protovis"
     },
     "Proximis Omnichannel": {
-      "cats": [
-        6,
-        1
-      ],
+      "cats": [6, 1],
       "html": "<html[^>]+data-ng-app=\"RbsChangeApp\"",
       "icon": "Proximis Omnichannel.png",
-      "implies": [
-        "PHP",
-        "AngularJS"
-      ],
+      "implies": ["PHP", "AngularJS"],
       "js": {
         "__change": ""
       },
@@ -8741,26 +6988,19 @@
       "website": "https://www.proximis.com"
     },
     "Proximis Web to Store": {
-      "cats": [
-        5,
-        6
-      ],
+      "cats": [5, 6],
       "icon": "Proximis Omnichannel.png",
       "script": "widget-commerce(?:\\.min)?\\.js",
       "website": "https://www.proximis.com"
     },
     "PubMatic": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "PubMatic.png",
       "script": "https?://[^/]*\\.pubmatic\\.com",
       "website": "http://www.pubmatic.com/"
     },
     "Public CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "PUBLICCMS_USER": ""
       },
@@ -8772,9 +7012,7 @@
       "website": "http://www.publiccms.com"
     },
     "Pure CSS": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": [
         "<link[^>]+(?:([\\d.])+/)?pure(?:-min)?\\.css\\;version:\\1",
         "<div[^>]+class=\"[^\"]*pure-u-(?:sm-|md-|lg-|xl-)?\\d-\\d"
@@ -8783,18 +7021,14 @@
       "website": "http://purecss.io"
     },
     "Pygments": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "cpe": "cpe:/a:pygments:pygments",
       "html": "<link[^>]+pygments\\.css[\"']",
       "icon": "pygments.png",
       "website": "http://pygments.org"
     },
     "PyroCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "pyrocms": ""
       },
@@ -8806,9 +7040,7 @@
       "website": "http://pyrocms.com"
     },
     "Python": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "cpe": "cpe:/a:python:python",
       "headers": {
         "Server": "(?:^|\\s)Python(?:/([\\d.]+))?\\;version:\\1"
@@ -8817,9 +7049,7 @@
       "website": "http://python.org"
     },
     "Quantcast": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Quantcast.png",
       "js": {
         "quantserve": ""
@@ -8828,9 +7058,7 @@
       "website": "http://www.quantcast.com"
     },
     "Question2Answer": {
-      "cats": [
-        15
-      ],
+      "cats": [15],
       "html": "<!-- Powered by Question2Answer",
       "icon": "question2answer.png",
       "implies": "PHP",
@@ -8838,9 +7066,7 @@
       "website": "http://www.question2answer.org"
     },
     "Quick.CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:opensolution:quick.cms",
       "html": "<a href=\"[^>]+opensolution\\.org/\">CMS by",
       "icon": "Quick.CMS.png",
@@ -8850,9 +7076,7 @@
       "website": "http://opensolution.org"
     },
     "Quick.Cart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<a href=\"[^>]+opensolution\\.org/\">(?:Shopping cart by|Sklep internetowy)",
       "icon": "Quick.Cart.png",
       "meta": {
@@ -8861,9 +7085,7 @@
       "website": "http://opensolution.org"
     },
     "Quill": {
-      "cats": [
-        24
-      ],
+      "cats": [24],
       "icon": "Quill.png",
       "js": {
         "Quill": ""
@@ -8871,10 +7093,7 @@
       "website": "http://quilljs.com"
     },
     "RBS Change": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "html": "<html[^>]+xmlns:change=",
       "icon": "RBS Change.png",
       "implies": "PHP",
@@ -8884,9 +7103,7 @@
       "website": "http://www.rbschange.fr"
     },
     "RCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "RCMS.png",
       "meta": {
         "generator": "^(?:RCMS|ReallyCMS)"
@@ -8894,9 +7111,7 @@
       "website": "http://www.rcms.fi"
     },
     "RD Station": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "icon": "RD Station.png",
       "js": {
         "RDStation": ""
@@ -8905,9 +7120,7 @@
       "website": "http://rdstation.com.br"
     },
     "RDoc": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "cpe": "cpe:/a:dave_thomas:rdoc",
       "html": [
         "<link[^>]+href=\"[^\"]*rdoc-style\\.css",
@@ -8922,9 +7135,7 @@
       "website": "https://github.com/ruby/rdoc"
     },
     "RackCache": {
-      "cats": [
-        23
-      ],
+      "cats": [23],
       "headers": {
         "X-Rack-Cache": ""
       },
@@ -8933,9 +7144,7 @@
       "website": "https://github.com/rtomayko/rack-cache"
     },
     "RainLoop": {
-      "cats": [
-        30
-      ],
+      "cats": [30],
       "headers": {
         "Server": "^RainLoop"
       },
@@ -8955,9 +7164,7 @@
       "website": "https://www.rainloop.net/"
     },
     "Rakuten DBCore": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Rakuten DBCore.png",
       "meta": {
         "generator": "Rakuten DBCore",
@@ -8966,9 +7173,7 @@
       "website": "http://ecservice.rakuten.com.br"
     },
     "Rakuten Digital Commerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "RakutenDigitalCommerce.png",
       "js": {
         "RakutenApplication": ""
@@ -8976,17 +7181,13 @@
       "website": "https://digitalcommerce.rakuten.com.br"
     },
     "Ramda": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Ramda.png",
       "script": "ramda.*\\.js",
       "website": "http://ramdajs.com"
     },
     "Raphael": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "Raphael.png",
       "js": {
         "Raphael.version": "^(.+)$\\;version:\\1"
@@ -8995,9 +7196,7 @@
       "website": "https://dmitrybaranovskiy.github.io/raphael/"
     },
     "Raspbian": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "headers": {
         "Server": "Raspbian",
         "X-Powered-By": "Raspbian"
@@ -9006,9 +7205,7 @@
       "website": "https://www.raspbian.org/"
     },
     "Raychat": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "raychat.png",
       "js": {
         "Raychat": ""
@@ -9017,14 +7214,9 @@
       "website": "https://raychat.io"
     },
     "Rayo": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Rayo.png",
-      "implies": [
-        "AngularJS",
-        "Microsoft ASP.NET"
-      ],
+      "implies": ["AngularJS", "Microsoft ASP.NET"],
       "js": {
         "Rayo": ""
       },
@@ -9034,15 +7226,11 @@
       "website": "http://www.rayo.ir"
     },
     "Rdf": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "website": "https://www.w3.org/RDF/"
     },
     "Redaxscript": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Redaxscript.svg",
       "implies": "PHP",
       "meta": {
@@ -9051,9 +7239,7 @@
       "website": "https://redaxscript.com"
     },
     "ReDoc": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "html": "<redoc ",
       "icon": "redoc.png",
       "implies": "React",
@@ -9064,9 +7250,7 @@
       "website": "https://github.com/Rebilly/ReDoc"
     },
     "React": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "cpe": "cpe:/a:facebook:react",
       "html": "<[^>]+data-react",
       "icon": "React.png",
@@ -9082,9 +7266,7 @@
       "website": "https://reactjs.org"
     },
     "Red Hat": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "cpe": "cpe:/o:redhat:linux",
       "headers": {
         "Server": "Red Hat",
@@ -9094,9 +7276,7 @@
       "website": "https://www.redhat.com"
     },
     "Reddit": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "html": "(?:<a[^>]+Powered by Reddit|powered by <a[^>]+>reddit<)",
       "icon": "Reddit.png",
       "implies": "Python",
@@ -9107,9 +7287,7 @@
       "website": "http://code.reddit.com"
     },
     "Redmine": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "cookies": {
         "_redmine_session": ""
       },
@@ -9123,9 +7301,7 @@
       "website": "http://www.redmine.org"
     },
     "Reinvigorate": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Reinvigorate.png",
       "js": {
         "reinvigorate": ""
@@ -9133,9 +7309,7 @@
       "website": "http://www.reinvigorate.net"
     },
     "RequireJS": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "RequireJS.png",
       "js": {
         "requirejs.version": "^(.+)$\\;version:\\1"
@@ -9144,9 +7318,7 @@
       "website": "http://requirejs.org"
     },
     "Resin": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:caucho:resin",
       "headers": {
         "Server": "^Resin(?:/(\\S*))?\\;version:\\1"
@@ -9156,9 +7328,7 @@
       "website": "http://caucho.com"
     },
     "Reveal.js": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Reveal.js.png",
       "implies": "Highlight.js",
       "js": {
@@ -9168,9 +7338,7 @@
       "website": "http://lab.hakim.se/reveal-js"
     },
     "Revel": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "REVEL_FLASH": "",
         "REVEL_SESSION": ""
@@ -9180,9 +7348,7 @@
       "website": "https://revel.github.io"
     },
     "Revslider": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": [
         "<link[^>]* href=[\\'\"][^']+revslider[/\\w-]+\\.css\\?ver=([0-9.]+)[\\'\"]\\;version:\\1"
       ],
@@ -9191,9 +7357,7 @@
       "website": "https://revolution.themepunch.com/"
     },
     "Rickshaw": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "implies": "D3",
       "js": {
         "Rickshaw": ""
@@ -9202,9 +7366,7 @@
       "website": "http://code.shutterstock.com/rickshaw/"
     },
     "RightJS": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "RightJS.png",
       "js": {
         "RightJS": ""
@@ -9213,9 +7375,7 @@
       "website": "http://rightjs.org"
     },
     "Riot": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Riot.png",
       "js": {
         "riot": ""
@@ -9224,41 +7384,28 @@
       "website": "https://riot.js.org/"
     },
     "RiteCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "RiteCMS.png",
-      "implies": [
-        "PHP",
-        "SQLite\\;confidence:80"
-      ],
+      "implies": ["PHP", "SQLite\\;confidence:80"],
       "meta": {
         "generator": "^RiteCMS(?: (.+))?\\;version:\\1"
       },
       "website": "http://ritecms.com"
     },
     "Roadiz CMS": {
-      "cats": [
-        1,
-        11
-      ],
+      "cats": [1, 11],
       "headers": {
         "X-Powered-By": "Roadiz CMS"
       },
       "icon": "Roadiz CMS.png",
-      "implies": [
-        "PHP",
-        "Symfony"
-      ],
+      "implies": ["PHP", "Symfony"],
       "meta": {
         "generator": "^Roadiz ?(?:master|develop)? v?([0-9\\.]+)\\;version:\\1"
       },
       "website": "https://www.roadiz.io"
     },
     "Robin": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Robin.png",
       "js": {
         "_robin_getRobinJs": "",
@@ -9268,26 +7415,16 @@
       "website": "http://www.robinhq.com"
     },
     "RockRMS": {
-      "cats": [
-        1,
-        11,
-        32
-      ],
+      "cats": [1, 11, 32],
       "icon": "RockRMS.svg",
-      "implies": [
-        "Windows Server",
-        "IIS",
-        "Microsoft ASP.NET"
-      ],
+      "implies": ["Windows Server", "IIS", "Microsoft ASP.NET"],
       "meta": {
         "generator": "^Rock v([0-9.]+)\\;version:\\1"
       },
       "website": "http://www.rockrms.com"
     },
     "RoundCube": {
-      "cats": [
-        30
-      ],
+      "cats": [30],
       "html": "<title>RoundCube",
       "icon": "RoundCube.png",
       "implies": "PHP",
@@ -9298,17 +7435,13 @@
       "website": "http://roundcube.net"
     },
     "Rubicon Project": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Rubicon Project.png",
       "script": "https?://[^/]*\\.rubiconproject\\.com",
       "website": "http://rubiconproject.com/"
     },
     "Ruby": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "headers": {
         "Server": "(?:Mongrel|WEBrick|Ruby)"
       },
@@ -9316,9 +7449,7 @@
       "website": "http://ruby-lang.org"
     },
     "Ruby on Rails": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "Server": "mod_(?:rails|rack)",
         "X-Powered-By": "mod_(?:rails|rack)"
@@ -9335,17 +7466,13 @@
       "website": "https://rubyonrails.org"
     },
     "Ruxit": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Ruxit.png",
       "script": "ruxitagentjs",
       "website": "http://ruxit.com"
     },
     "RxJS": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "RxJS.png",
       "js": {
         "Rx.CompositeDisposable": "",
@@ -9355,9 +7482,7 @@
       "website": "http://reactivex.io"
     },
     "S.Builder": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "S.Builder.png",
       "meta": {
         "generator": "S\\.Builder"
@@ -9365,9 +7490,7 @@
       "website": "http://www.sbuilder.ru"
     },
     "SAP": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "SAP NetWeaver Application Server"
       },
@@ -9375,50 +7498,32 @@
       "website": "http://sap.com"
     },
     "Sapper": {
-      "cats": [
-        18
-      ],
-      "html": [
-        "<script[^>]*>__SAPPER__"
-      ],
+      "cats": [18],
+      "html": ["<script[^>]*>__SAPPER__"],
       "icon": "Sapper.svg",
       "js": {
         "__SAPPER__": ""
       },
-      "implies": [
-        "Svelte",
-        "Node.js"
-      ],
+      "implies": ["Svelte", "Node.js"],
       "website": "https://sapper.svelte.dev"
     },
     "Scenari": {
-      "cats": [
-        1,
-        11
-      ],
+      "cats": [1, 11],
       "icon": "Scenari.png",
-      "implies": [
-        "Roadiz CMS",
-        "PHP",
-        "Symfony"
-      ],
+      "implies": ["Roadiz CMS", "PHP", "Symfony"],
       "meta": {
         "generator": "^Roadiz ?(?:master|develop)? v?[0-9\\.]+ - Scenari v?([0-9\\.]+)\\;version:\\1"
       },
       "website": "https://demo.scenari.site"
     },
     "SDL Tridion": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<img[^>]+_tcm\\d{2,3}-\\d{6}\\.",
       "icon": "SDL Tridion.png",
       "website": "http://www.sdl.com/products/tridion"
     },
     "Section.io": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "section-io-id": "",
         "section-io-origin-status": "",
@@ -9428,9 +7533,7 @@
       "website": "https://www.section.io"
     },
     "Sensors Data": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "js": {
         "sa.lib_version": "([\\d.]+)\\;version:\\1",
         "sensorsdata_app_js_bridge_call_js": ""
@@ -9444,9 +7547,7 @@
       "website": "https://www.sensorsdata.cn"
     },
     "Sentry": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "html": "<script[^>]*>\\s*Raven\\.config\\('[^']*', {\\s+release: '([0-9\\.]+)'\\;version:\\1",
       "js": {
         "__SENTRY__": "",
@@ -9459,9 +7560,7 @@
       "website": "https://sentry.io/"
     },
     "SIMsite": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "SIMsite.png",
       "meta": {
         "SIM.medium": ""
@@ -9470,9 +7569,7 @@
       "website": "http://simgroep.nl/internet/portfolio-contentbeheer_41623/"
     },
     "SMF": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "html": "credits/?\" title=\"Simple Machines Forum\" target=\"_blank\" class=\"new_win\">SMF ([0-9.]+)</a>\\;version:\\1",
       "icon": "SMF.png",
       "implies": "PHP",
@@ -9482,18 +7579,14 @@
       "website": "http://www.simplemachines.org"
     },
     "SOBI 2": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "(?:<!-- start of Sigsiu Online Business Index|<div[^>]* class=\"sobi2)",
       "icon": "SOBI 2.png",
       "implies": "Joomla",
       "website": "http://www.sigsiu.net/sobi2.html"
     },
     "SPDY": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "excludes": "HTTP/2",
       "headers": {
         "X-Firefox-Spdy": "\\d\\.\\d"
@@ -9502,9 +7595,7 @@
       "website": "http://chromium.org/spdy"
     },
     "SPIP": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "Composed-By": "SPIP ([\\d.]+) @\\;version:\\1",
         "X-Spip-Cache": ""
@@ -9517,25 +7608,19 @@
       "website": "http://www.spip.net"
     },
     "SQL Buddy": {
-      "cats": [
-        3
-      ],
+      "cats": [3],
       "html": "(?:<title>SQL Buddy</title>|<[^>]+onclick=\"sideMainClick\\(\"home\\.php)",
       "icon": "SQL Buddy.png",
       "implies": "PHP",
       "website": "http://www.sqlbuddy.com"
     },
     "SQLite": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "icon": "SQLite.png",
       "website": "http://www.sqlite.org"
     },
     "SUSE": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "headers": {
         "Server": "SUSE(?:/?\\s?-?([\\d.]+))?\\;version:\\1",
         "X-Powered-By": "SUSE(?:/?\\s?-?([\\d.]+))?\\;version:\\1"
@@ -9544,9 +7629,7 @@
       "website": "http://suse.com"
     },
     "Swiper Slider": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "<[^>]+=swiper-container",
       "js": {
         "Swiper": ""
@@ -9556,9 +7639,7 @@
       "website": "https://swiperjs.com"
     },
     "SWFObject": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "SWFObject.png",
       "js": {
         "SWFObject": ""
@@ -9567,9 +7648,7 @@
       "website": "https://github.com/swfobject/swfobject"
     },
     "Saia PCD": {
-      "cats": [
-        45
-      ],
+      "cats": [45],
       "headers": {
         "Server": "Saia PCD(?:([/a-z\\d.]+))?\\;version:\\1"
       },
@@ -9577,9 +7656,7 @@
       "website": "http://saia-pcd.com"
     },
     "Sails.js": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "sails.sid": ""
       },
@@ -9591,9 +7668,7 @@
       "website": "http://sailsjs.org"
     },
     "Salesforce": {
-      "cats": [
-        53
-      ],
+      "cats": [53],
       "cookies": {
         "com.salesforce": ""
       },
@@ -9608,9 +7683,7 @@
       "website": "https://www.salesforce.com"
     },
     "Salesforce Commerce Cloud": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "Server": "Demandware eCommerce Server"
       },
@@ -9623,9 +7696,7 @@
       "website": "http://demandware.com"
     },
     "Sarka-SPIP": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Sarka-SPIP.png",
       "implies": "SPIP",
       "meta": {
@@ -9634,9 +7705,7 @@
       "website": "http://sarka-spip.net"
     },
     "Sazito": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Sazito.svg",
       "js": {
         "Sazito": ""
@@ -9647,9 +7716,7 @@
       "website": "http://sazito.com"
     },
     "Phoenix": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "icon": "sazito-phoenix.png",
       "js": {
         "Phoenix": ""
@@ -9657,24 +7724,16 @@
       "meta": {
         "generator": "^phoenix"
       },
-      "implies": [
-        "React",
-        "webpack",
-        "Node.js"
-      ],
+      "implies": ["React", "webpack", "Node.js"],
       "website": "https://github.com/Sazito/phoenix/"
     },
     "Scala": {
-      "cats": [
-        27
-      ],
+      "cats": [27],
       "icon": "Scala.png",
       "website": "http://www.scala-lang.org"
     },
     "Scholica": {
-      "cats": [
-        21
-      ],
+      "cats": [21],
       "headers": {
         "X-Scholica-Version": ""
       },
@@ -9682,9 +7741,7 @@
       "website": "http://scholica.com"
     },
     "Scientific Linux": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "headers": {
         "Server": "Scientific Linux",
         "X-Powered-By": "Scientific Linux"
@@ -9693,9 +7750,7 @@
       "website": "http://scientificlinux.org"
     },
     "SeamlessCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "SeamlessCMS.png",
       "meta": {
         "generator": "^Seamless\\.?CMS"
@@ -9703,9 +7758,7 @@
       "website": "http://www.seamlesscms.com"
     },
     "Segment": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Segment.png",
       "js": {
         "analytics": ""
@@ -9714,9 +7767,7 @@
       "website": "https://segment.com"
     },
     "Select2": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Select2.png",
       "implies": "jQuery",
       "js": {
@@ -9726,43 +7777,29 @@
       "website": "https://select2.org/"
     },
     "Semantic-ui": {
-      "cats": [
-        66
-      ],
-      "html": [
-        "<link[^>]+semantic(?:\\.min)\\.css\""
-      ],
+      "cats": [66],
+      "html": ["<link[^>]+semantic(?:\\.min)\\.css\""],
       "icon": "Semantic-ui.png",
       "script": "/semantic(?:-([\\d.]+))?(?:\\.min)?\\.js\\;version:\\1",
       "website": "https://semantic-ui.com"
     },
     "Sencha Touch": {
-      "cats": [
-        12,
-        26
-      ],
+      "cats": [12, 26],
       "icon": "Sencha Touch.png",
       "script": "sencha-touch.*\\.js",
       "website": "http://sencha.com/products/touch"
     },
     "Seravo": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "x-powered-by": "^Seravo"
       },
-      "implies": [
-        "WordPress"
-      ],
+      "implies": ["WordPress"],
       "icon": "seravo.svg",
       "website": "https://seravo.com"
     },
     "Serendipity": {
-      "cats": [
-        1,
-        11
-      ],
+      "cats": [1, 11],
       "icon": "Serendipity.png",
       "implies": "PHP",
       "meta": {
@@ -9772,9 +7809,7 @@
       "website": "http://s9y.org"
     },
     "Shapecss": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": "<link[^>]* href=\"[^\"]*shapecss(?:\\.min)?\\.css",
       "icon": "Shapecss.svg",
       "js": {
@@ -9788,9 +7823,7 @@
       "website": "https://shapecss.com"
     },
     "ShareThis": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "ShareThis.png",
       "js": {
         "SHARETHIS": ""
@@ -9799,9 +7832,7 @@
       "website": "http://sharethis.com"
     },
     "ShellInABox": {
-      "cats": [
-        46
-      ],
+      "cats": [46],
       "html": [
         "<title>Shell In A Box</title>",
         "must be enabled for ShellInABox</noscript>"
@@ -9813,9 +7844,7 @@
       "website": "http://shellinabox.com"
     },
     "Shiny": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "icon": "Shiny.png",
       "js": {
         "Shiny.addCustomMessageHandler": ""
@@ -9823,9 +7852,7 @@
       "website": "https://shiny.rstudio.com"
     },
     "ShinyStat": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "html": "<img[^>]*\\s+src=['\"]?https?://www\\.shinystat\\.com/cgi-bin/shinystat\\.cgi\\?[^'\"\\s>]*['\"\\s/>]",
       "icon": "ShinyStat.png",
       "js": {
@@ -9835,9 +7862,7 @@
       "website": "http://shinystat.com"
     },
     "Shopatron": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": [
         "<body class=\"shopatron",
         "<img[^>]+mediacdn\\.shopatron\\.com\\;confidence:50"
@@ -9853,9 +7878,7 @@
       "website": "http://ecommerce.shopatron.com"
     },
     "Shopcada": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Shopcada.png",
       "js": {
         "Shopcada": ""
@@ -9863,9 +7886,7 @@
       "website": "http://shopcada.com"
     },
     "Shoper": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Shoper.svg",
       "js": {
         "shoper": ""
@@ -9873,24 +7894,16 @@
       "website": "https://www.shoper.pl"
     },
     "Shopery": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-Shopery": ""
       },
       "icon": "Shopery.svg",
-      "implies": [
-        "PHP",
-        "Symfony",
-        "Elcodi"
-      ],
+      "implies": ["PHP", "Symfony", "Elcodi"],
       "website": "http://shopery.com"
     },
     "Shopfa": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "js": {
         "shopfa": ""
       },
@@ -9904,9 +7917,7 @@
       "website": "https://shopfa.com"
     },
     "Shopify": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<link[^>]+=['\"]//cdn\\.shopify\\.com\\;confidence:25",
       "icon": "Shopify.svg",
       "js": {
@@ -9920,9 +7931,7 @@
       "website": "http://shopify.com"
     },
     "Shopline": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "shopline.png",
       "meta": {
         "og:image": "https\\:\\/\\/img\\.shoplineapp\\.com"
@@ -9930,9 +7939,7 @@
       "website": "https://shoplineapp.com/"
     },
     "Shoptet": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<link [^>]*href=\"https?://cdn\\.myshoptet\\.com/",
       "icon": "Shoptet.svg",
       "implies": "PHP",
@@ -9942,15 +7949,11 @@
       "meta": {
         "web_author": "^Shoptet"
       },
-      "script": [
-        "^https?://cdn\\.myshoptet\\.com/"
-      ],
+      "script": ["^https?://cdn\\.myshoptet\\.com/"],
       "website": "http://www.shoptet.cz"
     },
     "Shopware": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<title>Shopware ([\\d\\.]+) [^<]+\\;version:\\1",
       "headers": {
         "sw-context-token": "^[\\w]{32}$\\;version:6",
@@ -9959,12 +7962,7 @@
         "sw-version-id": "\\;version:6"
       },
       "icon": "Shopware.png",
-      "implies": [
-        "PHP",
-        "MySQL",
-        "jQuery",
-        "Symfony"
-      ],
+      "implies": ["PHP", "MySQL", "jQuery", "Symfony"],
       "meta": {
         "application-name": "Shopware"
       },
@@ -9976,9 +7974,7 @@
       "website": "https://www.shopware.com"
     },
     "Signal": {
-      "cats": [
-        32
-      ],
+      "cats": [32],
       "script": [
         "//s\\.btstatic\\.com/tag\\.js",
         "//s\\.thebrighttag\\.com/iframe\\?"
@@ -9990,9 +7986,7 @@
       "website": "https://www.signal.co/"
     },
     "Silva": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "SilvaCMS"
       },
@@ -10000,9 +7994,7 @@
       "website": "http://silvacms.org"
     },
     "SilverStripe": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "Powered by <a href=\"[^>]+SilverStripe",
       "icon": "SilverStripe.svg",
       "meta": {
@@ -10012,9 +8004,7 @@
       "website": "https://www.silverstripe.org"
     },
     "Simbel": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "powered": "simbel"
       },
@@ -10022,26 +8012,20 @@
       "website": "http://simbel.com.ar/"
     },
     "Simple Analytics": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "SimpleAnalytics.svg",
       "script": "^https:\\/\\/cdn\\.simpleanalytics\\.io\\/hello\\.js",
       "website": "https://simpleanalytics.com"
     },
     "SimpleHTTP": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "SimpleHTTP(?:/([\\d.]+))?\\;version:\\1"
       },
       "website": "http://example.com"
     },
     "Simplébo": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-ServedBy": "simplebo"
       },
@@ -10049,17 +8033,13 @@
       "website": "https://www.simplebo.fr"
     },
     "Site Meter": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Site Meter.png",
       "script": "sitemeter\\.com/js/counter\\.js\\?site=",
       "website": "http://www.sitemeter.com"
     },
     "SiteCatalyst": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "SiteCatalyst.png",
       "js": {
         "s_INST": "",
@@ -10071,9 +8051,7 @@
       "website": "http://www.adobe.com/solutions/digital-marketing.html"
     },
     "SiteEdit": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "SiteEdit.png",
       "meta": {
         "generator": "SiteEdit"
@@ -10081,9 +8059,7 @@
       "website": "http://www.siteedit.ru"
     },
     "Sitecore": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "SC_ANALYTICS_GLOBAL_COOKIE": ""
       },
@@ -10092,9 +8068,7 @@
       "website": "http://sitecore.net"
     },
     "SiteGround": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "host-header": "192fc2e7e50945beb8231a492d6a8024|b7440e60b07ee7b8044761568fab26e8|624d5be7be38418a3e2a818cc8b7029b|6b7412fb82ca5edfd0917e3957f05d89"
       },
@@ -10102,9 +8076,7 @@
       "website": "https://www.siteground.com"
     },
     "Sitefinity": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Sitefinity.svg",
       "implies": "Microsoft ASP.NET",
       "meta": {
@@ -10113,9 +8085,7 @@
       "website": "http://www.sitefinity.com"
     },
     "Sivuviidakko": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Sivuviidakko.png",
       "meta": {
         "generator": "Sivuviidakko"
@@ -10123,27 +8093,21 @@
       "website": "http://sivuviidakko.fi"
     },
     "Sizmek": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": "(?:<a [^>]*href=\"[^/]*//[^/]*serving-sys\\.com/|<img [^>]*src=\"[^/]*//[^/]*serving-sys\\.com/)",
       "icon": "Sizmek.png",
       "script": "serving-sys\\.com/",
       "website": "http://sizmek.com"
     },
     "Slick": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "html": "<link [^>]+(?:/([\\d.]+)/)?slick-theme\\.css\\;version:\\1",
       "implies": "jQuery",
       "script": "(?:/([\\d.]+))?/slick(?:\\.min)?\\.js\\;version:\\1",
       "website": "https://kenwheeler.github.io/slick"
     },
     "Slimbox": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "html": "<link [^>]*href=\"[^/]*slimbox(?:-rtl)?\\.css",
       "icon": "Slimbox.png",
       "implies": "MooTools",
@@ -10151,9 +8115,7 @@
       "website": "http://www.digitalia.be/software/slimbox"
     },
     "Slimbox 2": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "html": "<link [^>]*href=\"[^/]*slimbox2(?:-rtl)?\\.css",
       "icon": "Slimbox 2.png",
       "implies": "jQuery",
@@ -10161,9 +8123,7 @@
       "website": "http://www.digitalia.be/software/slimbox2"
     },
     "Smart Ad Server": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": "<img[^>]+smartadserver\\.com\\/call",
       "icon": "Smart Ad Server.png",
       "js": {
@@ -10172,9 +8132,7 @@
       "website": "http://smartadserver.com"
     },
     "SmartSite": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<[^>]+/smartsite\\.(?:dws|shtml)\\?id=",
       "icon": "SmartSite.png",
       "meta": {
@@ -10183,18 +8141,13 @@
       "website": "http://www.seneca.nl/pub/Smartsite/Smartsite-Smartsite-iXperion"
     },
     "Smartstore": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Smartstore.png",
       "script": "smjslib\\.js",
       "website": "http://smartstore.com"
     },
     "Snap": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "headers": {
         "Server": "Snap/([.\\d]+)\\;version:\\1"
       },
@@ -10203,9 +8156,7 @@
       "website": "http://snapframework.com"
     },
     "Snap.svg": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Snap.svg.png",
       "js": {
         "Snap.version": "^(.+)$\\;version:\\1"
@@ -10214,9 +8165,7 @@
       "website": "http://snapsvg.io"
     },
     "Snoobi": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Snoobi.png",
       "js": {
         "snoobi": ""
@@ -10225,9 +8174,7 @@
       "website": "http://www.snoobi.com"
     },
     "SobiPro": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "SobiPro.png",
       "implies": "Joomla",
       "js": {
@@ -10236,9 +8183,7 @@
       "website": "http://sigsiu.net/sobipro.html"
     },
     "Socket.io": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Socket.io.png",
       "implies": "Node.js",
       "js": {
@@ -10249,9 +8194,7 @@
       "website": "https://socket.io"
     },
     "SoftTr": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "softtr.png",
       "meta": {
         "author": "SoftTr E-Ticaret Sitesi Yazılımı"
@@ -10259,9 +8202,7 @@
       "website": "http://www.softtr.com"
     },
     "Solodev": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "solodev_session": ""
       },
@@ -10271,17 +8212,13 @@
       "website": "http://www.solodev.com"
     },
     "Solr": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "icon": "Solr.png",
       "implies": "Lucene",
       "website": "http://lucene.apache.org/solr/"
     },
     "Solusquare OmniCommerce Cloud": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "_solusquare": ""
       },
@@ -10293,10 +8230,7 @@
       "website": "https://www.solusquare.com"
     },
     "Solve Media": {
-      "cats": [
-        16,
-        36
-      ],
+      "cats": [16, 36],
       "icon": "Solve Media.png",
       "js": {
         "ACPuzzle": "",
@@ -10308,9 +8242,7 @@
       "website": "http://solvemedia.com"
     },
     "SonarQubes": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "html": [
         "<link href=\"/css/sonar\\.css\\?v=([\\d.]+)\\;version:\\1",
         "<title>SonarQube</title>"
@@ -10328,9 +8260,7 @@
       "website": "https://www.sonarqube.org/"
     },
     "SoundManager": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "SoundManager.png",
       "js": {
         "BaconPlayer": "",
@@ -10340,9 +8270,7 @@
       "website": "http://www.schillmania.com/projects/soundmanager2"
     },
     "Sphinx": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "html": "Created using <a href=\"https?://sphinx-doc\\.org/\">Sphinx</a> ([0-9.]+)\\.\\;version:\\1",
       "icon": "Sphinx.png",
       "js": {
@@ -10351,9 +8279,7 @@
       "website": "http://sphinx.pocoo.org"
     },
     "SpiderControl iniNet": {
-      "cats": [
-        45
-      ],
+      "cats": [45],
       "icon": "SpiderControl iniNet.png",
       "meta": {
         "generator": "iniNet SpiderControl"
@@ -10361,9 +8287,7 @@
       "website": "http://spidercontrol.net/ininet"
     },
     "SpinCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "spincms_session": ""
       },
@@ -10372,9 +8296,7 @@
       "website": "http://www.spin.cw"
     },
     "Splunk": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "<p class=\"footer\">&copy; [-\\d]+ Splunk Inc\\.(?: Splunk ([\\d\\.]+(?: build [\\d\\.]*\\d)?))?[^<]*</p>\\;version:\\1",
       "icon": "Splunk.png",
       "meta": {
@@ -10383,9 +8305,7 @@
       "website": "http://splunk.com"
     },
     "Splunkd": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Splunkd"
       },
@@ -10393,18 +8313,14 @@
       "website": "http://splunk.com"
     },
     "Spree": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "(?:<link[^>]*/assets/store/all-[a-z\\d]{32}\\.css[^>]+>|<script>\\s*Spree\\.(?:routes|translations|api_key))",
       "icon": "Spree.png",
       "implies": "Ruby on Rails",
       "website": "https://spreecommerce.org"
     },
     "Sqreen": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "headers": {
         "X-Protected-By": "^Sqreen$"
       },
@@ -10412,9 +8328,7 @@
       "website": "https://sqreen.io"
     },
     "Squarespace": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-ServedBy": "squarespace"
       },
@@ -10426,9 +8340,7 @@
       "website": "http://www.squarespace.com"
     },
     "SquirrelMail": {
-      "cats": [
-        30
-      ],
+      "cats": [30],
       "html": "<small>SquirrelMail version ([.\\d]+)[^<]*<br \\;version:\\1",
       "icon": "SquirrelMail.png",
       "implies": "PHP",
@@ -10439,9 +8351,7 @@
       "website": "http://squirrelmail.org"
     },
     "Squiz Matrix": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "Squiz Matrix"
       },
@@ -10454,9 +8364,7 @@
       "website": "http://squiz.net"
     },
     "Stackla": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Stackla.png",
       "js": {
         "Stackla": ""
@@ -10465,9 +8373,7 @@
       "website": "http://stackla.com/"
     },
     "Starlet": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "^Plack::Handler::Starlet"
       },
@@ -10476,9 +8382,7 @@
       "website": "http://metacpan.org/pod/Starlet"
     },
     "Statcounter": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Statcounter.svg",
       "js": {
         "_statcounter": "\\;confidence:100",
@@ -10489,17 +8393,13 @@
       "website": "http://www.statcounter.com"
     },
     "Store Systems": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "Shopsystem von <a href=[^>]+store-systems\\.de\"|\\.mws_boxTop",
       "icon": "Store Systems.png",
       "website": "http://store-systems.de"
     },
     "Storeden": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-Powered-By": "Storeden"
       },
@@ -10507,9 +8407,7 @@
       "website": "https://www.storeden.com"
     },
     "Storyblok": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "storyblok.png",
       "meta": {
         "generator": "storyblok"
@@ -10517,21 +8415,14 @@
       "website": "https://www.storyblok.com"
     },
     "Strapdown.js": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "strapdown.js.png",
-      "implies": [
-        "Bootstrap",
-        "Google Code Prettify"
-      ],
+      "implies": ["Bootstrap", "Google Code Prettify"],
       "script": "strapdown\\.js",
       "website": "http://strapdownjs.com"
     },
     "Strapi": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "^Strapi"
       },
@@ -10539,17 +8430,13 @@
       "website": "https://strapi.io"
     },
     "Strato": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<a href=\"http://www\\.strato\\.de/\" target=\"_blank\">",
       "icon": "strato.png",
       "website": "http://shop.strato.com"
     },
     "Stripe": {
-      "cats": [
-        41
-      ],
+      "cats": [41],
       "html": "<input[^>]+data-stripe",
       "icon": "Stripe.png",
       "js": {
@@ -10559,9 +8446,7 @@
       "website": "http://stripe.com"
     },
     "SublimeVideo": {
-      "cats": [
-        14
-      ],
+      "cats": [14],
       "icon": "SublimeVideo.png",
       "js": {
         "sublimevideo": ""
@@ -10570,9 +8455,7 @@
       "website": "http://sublimevideo.net"
     },
     "Subrion": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-CMS": "Subrion CMS"
       },
@@ -10584,9 +8467,7 @@
       "website": "http://subrion.com"
     },
     "Sucuri": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "x-sucuri-cache:": "",
         "x-sucuri-id": ""
@@ -10595,9 +8476,7 @@
       "website": "https://sucuri.net/"
     },
     "Sulu": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Generator": "Sulu/?(.+)?$\\;version:\\1"
       },
@@ -10606,18 +8485,13 @@
       "website": "http://sulu.io"
     },
     "SumoMe": {
-      "cats": [
-        5,
-        32
-      ],
+      "cats": [5, 32],
       "icon": "SumoMe.png",
       "script": "load\\.sumome\\.com",
       "website": "http://sumome.com"
     },
     "SunOS": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "headers": {
         "Server": "SunOS( [\\d\\.]+)?\\;version:\\1",
         "Servlet-engine": "SunOS( [\\d\\.]+)?\\;version:\\1"
@@ -10626,17 +8500,13 @@
       "website": "http://oracle.com/solaris"
     },
     "Supersized": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "Supersized.png",
       "script": "supersized(?:\\.([\\d.]*[\\d]))?.*\\.js\\;version:\\1",
       "website": "http://buildinternet.com/project/supersized"
     },
     "Svbtle": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "icon": "svbtle.png",
       "meta": {
         "generator": "^Svbtle\\.com$"
@@ -10645,17 +8515,13 @@
       "website": "https://www.svbtle.com"
     },
     "Svelte": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "html": "<[^>]+class=\\\"[^\\\"]+\\ssvelte-[\\w]*\\\"",
       "icon": "Svelte.svg",
       "website": "https://svelte.dev"
     },
     "SweetAlert": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "html": "<link[^>]+?href=\"[^\"]+sweet-alert(?:\\.min)?\\.css",
       "icon": "SweetAlert.png",
       "js": {
@@ -10665,9 +8531,7 @@
       "website": "https://t4t5.github.io/sweetalert/"
     },
     "SweetAlert2": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "excludes": "SweetAlert",
       "html": "<link[^>]+?href=\"[^\"]+sweetalert2(?:\\.min)?\\.css",
       "icon": "SweetAlert2.png",
@@ -10678,9 +8542,7 @@
       "website": "https://sweetalert2.github.io/"
     },
     "Swiftlet": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Generator": "Swiftlet",
         "X-Powered-By": "Swiftlet",
@@ -10695,9 +8557,7 @@
       "website": "http://swiftlet.org"
     },
     "Swiftype": {
-      "cats": [
-        29
-      ],
+      "cats": [29],
       "icon": "swiftype.png",
       "js": {
         "Swiftype": ""
@@ -10706,9 +8566,7 @@
       "website": "http://swiftype.com"
     },
     "Symfony": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "sf_redirect": ""
       },
@@ -10721,9 +8579,7 @@
       "website": "http://symfony.com"
     },
     "Sympa": {
-      "cats": [
-        30
-      ],
+      "cats": [30],
       "meta": {
         "generator": "^Sympa$"
       },
@@ -10733,9 +8589,7 @@
       "website": "https://www.sympa.org/"
     },
     "Synology DiskStation": {
-      "cats": [
-        48
-      ],
+      "cats": [48],
       "html": "<noscript><div class='syno-no-script'",
       "icon": "Synology DiskStation.png",
       "meta": {
@@ -10746,9 +8600,7 @@
       "website": "http://synology.com"
     },
     "SyntaxHighlighter": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "<(?:script|link)[^>]*sh(?:Core|Brush|ThemeDefault)",
       "icon": "SyntaxHighlighter.png",
       "js": {
@@ -10757,9 +8609,7 @@
       "website": "https://github.com/syntaxhighlighter"
     },
     "TWiki": {
-      "cats": [
-        8
-      ],
+      "cats": [8],
       "cookies": {
         "TWIKISID": ""
       },
@@ -10770,17 +8620,13 @@
       "website": "http://twiki.org"
     },
     "tailwindcss": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": "<link[^>]+?href=\"[^\"]+tailwindcss(?:\\.min)?\\.css",
       "icon": "tailwindcss.svg",
       "website": "https://tailwindcss.com/"
     },
     "TYPO3 CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": [
         "<link[^>]+ href=\"/?typo3(?:conf|temp)/",
         "<img[^>]+ src=\"/?typo3(?:conf|temp)/",
@@ -10796,31 +8642,22 @@
       "website": "https://typo3.org/"
     },
     "Taiga": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "icon": "Taiga.png",
-      "implies": [
-        "Django",
-        "AngularJS"
-      ],
+      "implies": ["Django", "AngularJS"],
       "js": {
         "taigaConfig": ""
       },
       "website": "http://taiga.io"
     },
     "Tawk.to": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "TawkTo.png",
       "script": "//embed\\.tawk\\.to",
       "website": "http://tawk.to"
     },
     "Tealeaf": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Tealeaf.png",
       "js": {
         "TeaLeaf": ""
@@ -10828,23 +8665,16 @@
       "website": "http://www.tealeaf.com"
     },
     "Tealium": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Tealium.png",
       "js": {
         "TEALIUMENABLED": ""
       },
-      "script": [
-        "^(?:https?:)?//tags\\.tiqcdn\\.com/",
-        "/tealium/utag\\.js$"
-      ],
+      "script": ["^(?:https?:)?//tags\\.tiqcdn\\.com/", "/tealium/utag\\.js$"],
       "website": "http://tealium.com"
     },
     "TeamCity": {
-      "cats": [
-        44
-      ],
+      "cats": [44],
       "html": "<span class=\"versionTag\"><span class=\"vWord\">Version</span> ([\\d\\.]+)\\;version:\\1",
       "icon": "TeamCity.svg",
       "implies": [
@@ -10862,49 +8692,32 @@
       "website": "https://www.jetbrains.com/teamcity/"
     },
     "Telescope": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Telescope.png",
-      "implies": [
-        "Meteor",
-        "React"
-      ],
+      "implies": ["Meteor", "React"],
       "js": {
         "Telescope": ""
       },
       "website": "http://telescopeapp.org"
     },
     "TN Express Web": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "TNEW": ""
       },
-      "implies": [
-        "Tessitura"
-      ],
+      "implies": ["Tessitura"],
       "icon": "tessitura.svg",
       "website": "https://www.tessituranetwork.com"
     },
     "Tessitura": {
-      "cats": [
-        53
-      ],
+      "cats": [53],
       "html": "<!--[^>]+Tessitura Version: (\\d*\\.\\d*\\.\\d*)?\\;version:\\1",
-      "implies": [
-        "Microsoft ASP.NET",
-        "IIS",
-        "Windows Server"
-      ],
+      "implies": ["Microsoft ASP.NET", "IIS", "Windows Server"],
       "icon": "tessitura.svg",
       "website": "https://www.tessituranetwork.com"
     },
     "Tengine": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Tengine"
       },
@@ -10912,9 +8725,7 @@
       "website": "http://tengine.taobao.org"
     },
     "Textalk": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "textalk.png",
       "meta": {
         "generator": "Textalk Webshop"
@@ -10922,36 +8733,23 @@
       "website": "https://www.textalk.se"
     },
     "Textpattern CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Textpattern CMS.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "meta": {
         "generator": "Textpattern"
       },
       "website": "http://textpattern.com"
     },
     "Thelia": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "html": "<(?:link|style|script)[^>]+/assets/frontOffice/",
       "icon": "Thelia.png",
-      "implies": [
-        "PHP",
-        "Symfony"
-      ],
+      "implies": ["PHP", "Symfony"],
       "website": "http://thelia.net"
     },
     "ThinkPHP": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Powered-By": "ThinkPHP"
       },
@@ -10960,30 +8758,19 @@
       "website": "http://www.thinkphp.cn"
     },
     "Ticimax": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Ticimax.png",
-      "script": [
-        "cdn\\.ticimax\\.com/"
-      ],
+      "script": ["cdn\\.ticimax\\.com/"],
       "website": "https://www.ticimax.com"
     },
     "Tictail": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<link[^>]*tictail\\.com",
       "icon": "tictail.png",
       "website": "https://tictail.com"
     },
     "TiddlyWiki": {
-      "cats": [
-        1,
-        2,
-        4,
-        8
-      ],
+      "cats": [1, 2, 4, 8],
       "html": "<[^>]*type=[^>]text\\/vnd\\.tiddlywiki",
       "icon": "TiddlyWiki.png",
       "js": {
@@ -10998,13 +8785,7 @@
       "website": "http://tiddlywiki.com"
     },
     "Tiki Wiki CMS Groupware": {
-      "cats": [
-        1,
-        2,
-        8,
-        11,
-        13
-      ],
+      "cats": [1, 2, 8, 11, 13],
       "icon": "Tiki Wiki CMS Groupware.png",
       "meta": {
         "generator": "^Tiki"
@@ -11013,18 +8794,14 @@
       "website": "http://tiki.org"
     },
     "Tilda": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<link[^>]* href=[^>]+tilda(?:cdn|\\.ws|-blocks)",
       "icon": "Tilda.svg",
       "script": "tilda(?:cdn|\\.ws|-blocks)",
       "website": "https://tilda.cc"
     },
     "Timeplot": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "Timeplot.png",
       "js": {
         "Timeplot": ""
@@ -11033,9 +8810,7 @@
       "website": "http://www.simile-widgets.org/timeplot/"
     },
     "TinyMCE": {
-      "cats": [
-        24
-      ],
+      "cats": [24],
       "icon": "TinyMCE.png",
       "js": {
         "tinyMCE.majorVersion": "([\\d.]+)\\;version:\\1"
@@ -11044,9 +8819,7 @@
       "website": "http://tinymce.com"
     },
     "Titan": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Titan.png",
       "js": {
         "titan": "",
@@ -11055,9 +8828,7 @@
       "website": "http://titan360.com"
     },
     "TomatoCart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "TomatoCart.png",
       "js": {
         "AjaxShoppingCart": ""
@@ -11068,9 +8839,7 @@
       "website": "http://tomatocart.com"
     },
     "TornadoServer": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "TornadoServer(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -11078,9 +8847,7 @@
       "website": "http://tornadoweb.org"
     },
     "TotalCode": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-Powered-By": "^TotalCode$"
       },
@@ -11088,9 +8855,7 @@
       "website": "http://www.totalcode.com"
     },
     "Trac": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "html": [
         "<a id=\"tracpowered",
         "Powered by <a href=\"[^\"]*\"><strong>Trac(?:[ /]([\\d.]+))?\\;version:\\1"
@@ -11100,9 +8865,7 @@
       "website": "http://trac.edgewall.org"
     },
     "TrackJs": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "TrackJs.png",
       "js": {
         "TrackJs": ""
@@ -11111,9 +8874,7 @@
       "website": "http://trackjs.com"
     },
     "Transifex": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "transifex.png",
       "js": {
         "Transifex.live.lib_version": "(.+)\\;version:\\1"
@@ -11121,29 +8882,20 @@
       "website": "https://www.transifex.com"
     },
     "Translucide": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "translucide.svg",
-      "implies": [
-        "PHP",
-        "jQuery"
-      ],
+      "implies": ["PHP", "jQuery"],
       "script": "lucide\\.init(?:\\.min)?\\.js",
       "website": "http://www.translucide.net"
     },
     "Tray": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "tray.png",
       "script": "tcdn\\.com\\.br",
       "website": "https://www.tray.com.br"
     },
     "Tumblr": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "headers": {
         "X-Tumblr-User": ""
       },
@@ -11153,9 +8905,7 @@
       "website": "http://www.tumblr.com"
     },
     "TweenMax": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "TweenMax.png",
       "js": {
         "TweenMax.version": "^(.+)$\\;version:\\1"
@@ -11164,9 +8914,7 @@
       "website": "http://greensock.com/tweenmax"
     },
     "Twilight CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-CMS": "Twilight CMS"
       },
@@ -11174,9 +8922,7 @@
       "website": "http://www.twilightcms.com"
     },
     "TwistPHP": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Powered-By": "TwistPHP"
       },
@@ -11185,9 +8931,7 @@
       "website": "http://twistphp.com"
     },
     "TwistedWeb": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "TwistedWeb(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -11195,17 +8939,13 @@
       "website": "http://twistedmatrix.com/trac/wiki/TwistedWeb"
     },
     "Twitter": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "icon": "Twitter.svg",
       "script": "//platform\\.twitter\\.com/widgets\\.js",
       "website": "http://twitter.com"
     },
     "Twitter Emoji (Twemoji)": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "js": {
         "twemoji": ""
       },
@@ -11213,9 +8953,7 @@
       "website": "https://twitter.github.io/twemoji/"
     },
     "Twitter Flight": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Twitter Flight.png",
       "implies": "jQuery",
       "js": {
@@ -11224,9 +8962,7 @@
       "website": "https://flightjs.github.io/"
     },
     "Twitter typeahead.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Twitter typeahead.js.png",
       "implies": "jQuery",
       "js": {
@@ -11236,9 +8972,7 @@
       "website": "https://twitter.github.io/typeahead.js"
     },
     "TypePad": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "icon": "TypePad.png",
       "meta": {
         "generator": "typepad"
@@ -11247,9 +8981,7 @@
       "website": "http://www.typepad.com"
     },
     "Typecho": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "icon": "typecho.svg",
       "implies": "PHP",
       "js": {
@@ -11262,9 +8994,7 @@
       "website": "http://typecho.org/"
     },
     "Typekit": {
-      "cats": [
-        17
-      ],
+      "cats": [17],
       "icon": "Typekit.png",
       "js": {
         "Typekit.config.js": "^(.+)$\\;version:\\1"
@@ -11273,18 +9003,14 @@
       "website": "http://typekit.com"
     },
     "UIKit": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": "<[^>]+class=\"[^\"]*(?:uk-container|uk-section)",
       "icon": "UIKit.png",
       "script": "uikit.*\\.js",
       "website": "https://getuikit.com"
     },
     "UMI.CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Generated-By": "UMI\\.CMS"
       },
@@ -11293,9 +9019,7 @@
       "website": "https://www.umi-cms.ru"
     },
     "UNIX": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "headers": {
         "Server": "Unix"
       },
@@ -11303,18 +9027,14 @@
       "website": "http://unix.org"
     },
     "Ubercart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Ubercart.png",
       "implies": "Drupal",
       "script": "uc_cart/uc_cart_block\\.js",
       "website": "http://www.ubercart.org"
     },
     "Ubuntu": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "headers": {
         "Server": "Ubuntu",
         "X-Powered-By": "Ubuntu"
@@ -11323,9 +9043,7 @@
       "website": "http://www.ubuntu.com/server"
     },
     "UltraCart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<form [^>]*action=\"[^\"]*\\/cgi-bin\\/UCEditor\\?(?:[^\"]*&)?merchantId=[^\"]",
       "icon": "UltraCart.png",
       "js": {
@@ -11336,9 +9054,7 @@
       "website": "http://ultracart.com"
     },
     "Umbraco": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Umbraco-Version": "^(.+)$\\;version:\\1"
       },
@@ -11358,10 +9074,7 @@
       "website": "http://umbraco.com"
     },
     "Unbounce": {
-      "cats": [
-        20,
-        51
-      ],
+      "cats": [20, 51],
       "headers": {
         "X-Unbounce-PageId": ""
       },
@@ -11370,9 +9083,7 @@
       "website": "http://unbounce.com"
     },
     "Underscore.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "excludes": "Lodash",
       "icon": "Underscore.js.png",
       "js": {
@@ -11383,9 +9094,7 @@
       "website": "http://underscorejs.org"
     },
     "Usabilla": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "icon": "Usabilla.svg",
       "js": {
         "usabilla_live": ""
@@ -11393,9 +9102,7 @@
       "website": "http://usabilla.com"
     },
     "user.com": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "html": "<div[^>]+/id=\"ue_widget\"",
       "icon": "user.com.svg",
       "js": {
@@ -11404,34 +9111,20 @@
       "website": "https://user.com"
     },
     "UserGuiding": {
-      "cats": [
-        58,
-        10
-      ],
+      "cats": [58, 10],
       "icon": "UserGuiding.svg",
-      "implies": [
-        "React",
-        "webpack",
-        "Node.js"
-      ],
+      "implies": ["React", "webpack", "Node.js"],
       "script": "static\\.userguiding*\\.js",
       "website": "https://userguiding.com"
     },
     "UserLike": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "UserLike.svg",
-      "script": [
-        "userlike\\.min\\.js",
-        "userlikelib\\.min\\.js"
-      ],
+      "script": ["userlike\\.min\\.js", "userlikelib\\.min\\.js"],
       "website": "http://userlike.com"
     },
     "UserRules": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "icon": "UserRules.png",
       "js": {
         "_usrp": ""
@@ -11439,9 +9132,7 @@
       "website": "http://www.userrules.com"
     },
     "UserVoice": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "icon": "UserVoice.png",
       "js": {
         "UserVoice": ""
@@ -11449,19 +9140,12 @@
       "website": "http://uservoice.com"
     },
     "Ushahidi": {
-      "cats": [
-        1,
-        35
-      ],
+      "cats": [1, 35],
       "cookies": {
         "ushahidi": ""
       },
       "icon": "Ushahidi.png",
-      "implies": [
-        "PHP",
-        "MySQL",
-        "OpenLayers"
-      ],
+      "implies": ["PHP", "MySQL", "OpenLayers"],
       "js": {
         "Ushahidi": ""
       },
@@ -11469,9 +9153,7 @@
       "website": "http://www.ushahidi.com"
     },
     "VIVVO": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "VivvoSessionId": ""
       },
@@ -11482,9 +9164,7 @@
       "website": "http://vivvo.net"
     },
     "VP-ASP": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<a[^>]+>Powered By VP-ASP Shopping Cart</a>",
       "icon": "VP-ASP.png",
       "implies": "Microsoft ASP.NET",
@@ -11492,9 +9172,7 @@
       "website": "http://www.vpasp.com"
     },
     "VTEX": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "VtexWorkspace": "",
         "VtexFingerPrint": "",
@@ -11508,9 +9186,7 @@
       "website": "https://vtex.com/"
     },
     "VTEX Integrated Store": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-Powered-By": "vtex-integrated-store"
       },
@@ -11518,9 +9194,7 @@
       "website": "http://lojaintegrada.com.br"
     },
     "Vaadin": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "icon": "Vaadin.svg",
       "implies": "Java",
       "js": {
@@ -11530,9 +9204,7 @@
       "website": "https://vaadin.com"
     },
     "Vanilla": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "headers": {
         "X-Powered-By": "Vanilla"
       },
@@ -11542,9 +9214,7 @@
       "website": "http://vanillaforums.org"
     },
     "Varnish": {
-      "cats": [
-        23
-      ],
+      "cats": [23],
       "headers": {
         "Via": "varnish(?: \\(Varnish/([\\d.]+)\\))?\\;version:\\1",
         "X-Varnish": "",
@@ -11557,9 +9227,7 @@
       "website": "http://www.varnish-cache.org"
     },
     "Venda": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-venda-hitid": ""
       },
@@ -11567,9 +9235,7 @@
       "website": "http://venda.com"
     },
     "Veoxa": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": "<img [^>]*src=\"[^\"]+tracking\\.veoxa\\.com",
       "icon": "Veoxa.png",
       "js": {
@@ -11579,9 +9245,7 @@
       "website": "http://veoxa.com"
     },
     "VideoJS": {
-      "cats": [
-        14
-      ],
+      "cats": [14],
       "html": "<div[^>]+class=\"video-js+\">",
       "icon": "VideoJS.svg",
       "js": {
@@ -11596,9 +9260,7 @@
       "website": "http://videojs.com"
     },
     "VigLink": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "VigLink.png",
       "js": {
         "vglnk": "",
@@ -11609,9 +9271,7 @@
       "website": "http://viglink.com"
     },
     "Vigbo": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "_gphw_mode": ""
       },
@@ -11621,34 +9281,26 @@
       "website": "https://vigbo.com"
     },
     "Vignette": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<[^>]+=\"vgn-?ext",
       "icon": "Vignette.png",
       "website": "http://www.vignette.com"
     },
     "Vimeo": {
-      "cats": [
-        14
-      ],
+      "cats": [14],
       "html": "(?:<(?:param|embed)[^>]+vimeo\\.com/moogaloop|<iframe[^>]player\\.vimeo\\.com)",
       "icon": "Vimeo.png",
       "website": "http://vimeo.com"
     },
     "VirtueMart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<div id=\"vmMainPage",
       "icon": "VirtueMart.png",
       "implies": "Joomla",
       "website": "http://virtuemart.net"
     },
     "Virtuoso": {
-      "cats": [
-        34
-      ],
+      "cats": [34],
       "headers": {
         "Server": "Virtuoso/?([0-9.]+)?\\;version:\\1"
       },
@@ -11660,9 +9312,7 @@
       "website": "https://virtuoso.openlinksw.com/"
     },
     "Visual Website Optimizer": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "html": [
         "<!-- (?:Start|End) Visual Website Optimizer A?Synchronous Code -->"
       ],
@@ -11671,23 +9321,17 @@
         "VWO": "",
         "__vwo": ""
       },
-      "script": [
-        "dev\\.visualwebsiteoptimizer\\.com"
-      ],
+      "script": ["dev\\.visualwebsiteoptimizer\\.com"],
       "website": "https://vwo.com/"
     },
     "VisualPath": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "VisualPath.png",
       "script": "visualpath[^/]*\\.trackset\\.it/[^/]+/track/include\\.js",
       "website": "http://www.trackset.com/web-analytics-software/visualpath"
     },
     "Volusion (V1)": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<link [^>]*href=\"[^\"]*/vspfiles/",
       "icon": "Volusion.svg",
       "implies": "Microsoft ASP.NET",
@@ -11698,18 +9342,14 @@
       "website": "https://www.volusion.com"
     },
     "Volusion (V2)": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<body [^>]*data-vn-page-name",
       "icon": "Volusion.svg",
       "implies": "AngularJS",
       "website": "https://www.volusion.com"
     },
     "Vue.js": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "html": "<[^>]+\\sdata-v(?:ue)?-",
       "icon": "Vue.js.png",
       "js": {
@@ -11722,27 +9362,18 @@
       "website": "http://vuejs.org"
     },
     "Nuxt.js": {
-      "cats": [
-        12
-      ],
-      "html": [
-        "<div [^>]*id=\"__nuxt\"",
-        "<script [^>]*>window\\.__NUXT__"
-      ],
+      "cats": [12],
+      "html": ["<div [^>]*id=\"__nuxt\"", "<script [^>]*>window\\.__NUXT__"],
       "icon": "Nuxt.js.svg",
       "js": {
         "$nuxt": ""
       },
-      "script": [
-        "/_nuxt/"
-      ],
+      "script": ["/_nuxt/"],
       "implies": "Vue.js",
       "website": "https://nuxtjs.org"
     },
     "W3 Total Cache": {
-      "cats": [
-        23
-      ],
+      "cats": [23],
       "headers": {
         "X-Powered-By": "W3 Total Cache(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -11752,17 +9383,13 @@
       "website": "http://www.w3-edge.com/wordpress-plugins/w3-total-cache"
     },
     "W3Counter": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "W3Counter.png",
       "script": "w3counter\\.com/tracker\\.js",
       "website": "http://www.w3counter.com"
     },
     "WEBXPAY": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "Powered by <a href=\"https://www\\.webxpay\\.com\">WEBXPAY<",
       "icon": "WEBXPAY.png",
       "js": {
@@ -11771,9 +9398,7 @@
       "website": "https://webxpay.com"
     },
     "WHMCS": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "WHMCS": ""
       },
@@ -11781,9 +9406,7 @@
       "website": "http://www.whmcs.com"
     },
     "WP Rocket": {
-      "cats": [
-        23
-      ],
+      "cats": [23],
       "headers": {
         "X-Powered-By": "WP Rocket(?:/([\\d.]+))?\\;version:\\1",
         "X-Rocket-Nginx-Bypass": ""
@@ -11794,22 +9417,19 @@
       "website": "http://wp-rocket.me"
     },
     "WP Engine": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "wpe-backend": "",
         "X-Pass-Why": "",
-        "X-WPE-Loopback-Upstream-Addr": ""
+        "X-WPE-Loopback-Upstream-Addr": "",
+        "X-Powered-By": "WP Engine"
       },
       "icon": "wpengine.svg",
       "implies": "WordPress",
       "website": "https://wpengine.com"
     },
     "Warp": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "^Warp/(\\d+(?:\\.\\d+)+)?$\\;version:\\1"
       },
@@ -11818,17 +9438,12 @@
       "website": "http://www.stackage.org/package/warp"
     },
     "Web2py": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Powered-By": "web2py"
       },
       "icon": "Web2py.png",
-      "implies": [
-        "Python",
-        "jQuery"
-      ],
+      "implies": ["Python", "jQuery"],
       "meta": {
         "generator": "^Web2py"
       },
@@ -11836,9 +9451,7 @@
       "website": "http://web2py.com"
     },
     "Webflow": {
-      "cats": [
-        51
-      ],
+      "cats": [51],
       "html": "<html[^>]+data-wf-site",
       "icon": "webflow.svg",
       "js": {
@@ -11850,9 +9463,7 @@
       "website": "https://webflow.com"
     },
     "WebGUI": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "wgSession": ""
       },
@@ -11864,9 +9475,7 @@
       "website": "http://www.webgui.org"
     },
     "WebPublisher": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "WebPublisher.png",
       "meta": {
         "generator": "WEB\\|Publisher"
@@ -11874,9 +9483,7 @@
       "website": "http://scannet.dk"
     },
     "WebSite X5": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "icon": "WebSite X5.png",
       "meta": {
         "generator": "Incomedia WebSite X5 (\\w+ [\\d.]+)\\;version:\\1"
@@ -11884,9 +9491,7 @@
       "website": "http://websitex5.com"
     },
     "Webdev": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "headers": {
         "WebDevSrc": ""
       },
@@ -11898,9 +9503,7 @@
       "website": "https://www.windev.com/webdev/index.html"
     },
     "Webix": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "Webix.png",
       "js": {
         "webix": ""
@@ -11909,17 +9512,13 @@
       "website": "http://webix.com"
     },
     "Webmine": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "html": "<iframe[^>]+src=[\\'\"]https://webmine\\.cz/miner\\?key=",
       "icon": "webmine.png",
       "website": "https://webmine.cz/"
     },
     "Webs": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "Server": "Webs\\.com/?([\\d\\.]+)?\\;version:\\1"
       },
@@ -11927,9 +9526,7 @@
       "website": "http://webs.com"
     },
     "Websocket": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": [
         "<link[^>]+rel=[\"']web-socket[\"']",
         "<(?:link|a)[^>]+href=[\"']wss?://"
@@ -11938,9 +9535,7 @@
       "website": "https://en.wikipedia.org/wiki/WebSocket"
     },
     "WebsPlanet": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "WebsPlanet.png",
       "meta": {
         "generator": "WebsPlanet"
@@ -11948,9 +9543,7 @@
       "website": "http://websplanet.com"
     },
     "Websale": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Websale.png",
       "cookies": {
         "websale_ac": ""
@@ -11958,15 +9551,9 @@
       "website": "http://websale.de"
     },
     "Website Creator": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "WebsiteCreator.png",
-      "implies": [
-        "PHP",
-        "MySQL",
-        "Vue.js"
-      ],
+      "implies": ["PHP", "MySQL", "Vue.js"],
       "meta": {
         "generator": "Website Creator by hosttech",
         "wsc_rendermode": ""
@@ -11974,23 +9561,16 @@
       "website": "https://www.hosttech.ch/websitecreator"
     },
     "WebsiteBaker": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "WebsiteBaker.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "meta": {
         "generator": "WebsiteBaker"
       },
       "website": "http://websitebaker2.org/en/home.php"
     },
     "Webtrekk": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Webtrekk.png",
       "js": {
         "webtrekk": "",
@@ -12006,9 +9586,7 @@
       "website": "http://www.webtrekk.com"
     },
     "Webtrends": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "html": "<img[^>]+id=\"DCSIMG\"[^>]+webtrends",
       "icon": "Webtrends.png",
       "js": {
@@ -12018,14 +9596,9 @@
       "website": "http://worldwide.webtrends.com"
     },
     "Weebly": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Weebly.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "js": {
         "_W.configDomain": ""
       },
@@ -12033,23 +9606,16 @@
       "website": "https://www.weebly.com"
     },
     "Weglot": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "headers": {
         "Weglot-Translated": ""
       },
       "icon": "Weglot.png",
-      "script": [
-        "cdn\\.weglot\\.com",
-        "wp-content/plugins/weglot"
-      ],
+      "script": ["cdn\\.weglot\\.com", "wp-content/plugins/weglot"],
       "website": "https://www.weglot.com"
     },
     "Webzi": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "Webzi.svg",
       "js": {
         "Webzi": ""
@@ -12061,27 +9627,19 @@
       "website": "https://webzi.ir"
     },
     "Whooshkaa": {
-      "cats": [
-        5
-      ],
+      "cats": [5],
       "html": "<iframe src=\"[^>]+whooshkaa\\.com",
       "icon": "Whooshkaa.svg",
       "website": "https://www.whooshkaa.com"
     },
     "Wikinggruppen": {
-      "cats": [
-        6
-      ],
-      "html": [
-        "<!-- WIKINGGRUPPEN"
-      ],
+      "cats": [6],
+      "html": ["<!-- WIKINGGRUPPEN"],
       "icon": "wikinggruppen.png",
       "website": "https://wikinggruppen.se/"
     },
     "WikkaWiki": {
-      "cats": [
-        8
-      ],
+      "cats": [8],
       "html": "Powered by <a href=\"[^>]+WikkaWiki",
       "icon": "WikkaWiki.png",
       "meta": {
@@ -12090,9 +9648,7 @@
       "website": "http://wikkawiki.org"
     },
     "Windows CE": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "headers": {
         "Server": "\\bWinCE\\b"
       },
@@ -12100,9 +9656,7 @@
       "website": "http://microsoft.com"
     },
     "Windows Server": {
-      "cats": [
-        28
-      ],
+      "cats": [28],
       "headers": {
         "Server": "Win32|Win64"
       },
@@ -12110,10 +9664,7 @@
       "website": "http://microsoft.com/windowsserver"
     },
     "Wink": {
-      "cats": [
-        26,
-        12
-      ],
+      "cats": [26, 12],
       "icon": "Wink.png",
       "js": {
         "wink.version": "^(.+)$\\;version:\\1"
@@ -12122,9 +9673,7 @@
       "website": "http://winktoolkit.org"
     },
     "Winstone Servlet Container": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Winstone Servlet (?:Container|Engine) v?([\\d.]+)?\\;version:\\1",
         "X-Powered-By": "Winstone(?:.([\\d.]+))?\\;version:\\1"
@@ -12132,11 +9681,7 @@
       "website": "http://winstone.sourceforge.net"
     },
     "Wix": {
-      "cats": [
-        1,
-        6,
-        11
-      ],
+      "cats": [1, 6, 11],
       "cookies": {
         "Domain": "\\.wix\\.com"
       },
@@ -12146,9 +9691,7 @@
         "X-Wix-Server-Artifact-Id": ""
       },
       "icon": "Wix.png",
-      "implies": [
-        "React"
-      ],
+      "implies": ["React"],
       "js": {
         "wixBiSession": ""
       },
@@ -12159,18 +9702,14 @@
       "website": "https://www.wix.com"
     },
     "Wolf CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "(?:<a href=\"[^>]+wolfcms\\.org[^>]+>Wolf CMS(?:</a>)? inside|Thank you for using <a[^>]+>Wolf CMS)",
       "icon": "Wolf CMS.png",
       "implies": "PHP",
       "website": "http://www.wolfcms.org"
     },
     "Woltlab Community Framework": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "var WCF_PATH[^>]+",
       "icon": "Woltlab Community Framework.png",
       "implies": "PHP",
@@ -12178,9 +9717,7 @@
       "website": "http://www.woltlab.com"
     },
     "WooCommerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": [
         "<!-- WooCommerce",
         "<link rel='[^']+' id='woocommerce-(?:layout|smallscreen|general)-css'  href='https?://[^/]+/wp-content/plugins/woocommerce/assets/css/woocommerce(?:-layout|-smallscreen)?\\.css?ver=([\\d.]+)'\\;version:\\1"
@@ -12197,22 +9734,14 @@
       "website": "http://www.woothemes.com/woocommerce"
     },
     "Woopra": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Woopra.png",
       "script": "static\\.woopra\\.com",
       "website": "http://www.woopra.com"
     },
     "Woosa": {
-      "cats": [
-        1,
-        6
-      ],
-      "excludes": [
-        "WordPress",
-        "WooCommerce"
-      ],
+      "cats": [1, 6],
+      "excludes": ["WordPress", "WooCommerce"],
       "icon": "Woosa.png",
       "meta": {
         "generator": "^Woosa$"
@@ -12220,19 +9749,13 @@
       "website": "https://woosa.nl"
     },
     "WordPress": {
-      "cats": [
-        1,
-        11
-      ],
+      "cats": [1, 11],
       "html": [
         "<link rel=[\"']stylesheet[\"'] [^>]+/wp-(?:content|includes)/",
         "<link[^>]+s\\d+\\.wp\\.com"
       ],
       "icon": "WordPress.svg",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "headers": {
         "link": "rel=\"https://api\\.w\\.org/\""
       },
@@ -12246,9 +9769,7 @@
       "website": "https://wordpress.org"
     },
     "WordPress Super Cache": {
-      "cats": [
-        23
-      ],
+      "cats": [23],
       "headers": {
         "WP-Super-Cache": ""
       },
@@ -12258,30 +9779,22 @@
       "website": "http://z9.io/wp-super-cache/"
     },
     "WordPress VIP": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "x-powered-by": "^WordPress.com VIP"
       },
-      "implies": [
-        "WordPress"
-      ],
+      "implies": ["WordPress"],
       "icon": "wpvip.svg",
       "website": "https://wpvip.com"
     },
     "Wowza Media Server": {
-      "cats": [
-        38
-      ],
+      "cats": [38],
       "html": "<title>Wowza Media Server \\d+ ((?:\\w+ Edition )?\\d+\\.[\\d\\.]+(?: build\\d+)?)?\\;version:\\1",
       "icon": "Wowza Media Server.png",
       "website": "http://www.wowza.com"
     },
     "X-Cart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "xid": "[a-z\\d]{32}(?:;|$)"
       },
@@ -12302,34 +9815,23 @@
       "website": "http://x-cart.com"
     },
     "XAMPP": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "html": "<title>XAMPP(?: Version ([\\d\\.]+))?</title>\\;version:\\1",
       "icon": "XAMPP.png",
-      "implies": [
-        "Apache",
-        "MySQL",
-        "PHP",
-        "Perl"
-      ],
+      "implies": ["Apache", "MySQL", "PHP", "Perl"],
       "meta": {
         "author": "Kai Oswald Seidler\\;confidence:10"
       },
       "website": "http://www.apachefriends.org/en/xampp.html"
     },
     "XMB": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "html": "<!-- Powered by XMB",
       "icon": "XMB.png",
       "website": "http://www.xmbforum.com"
     },
     "XOOPS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "XOOPS.png",
       "implies": "PHP",
       "js": {
@@ -12341,9 +9843,7 @@
       "website": "http://xoops.org"
     },
     "XRegExp": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "XRegExp.png",
       "js": {
         "XRegExp.version": "^(.+)$\\;version:\\1"
@@ -12356,13 +9856,9 @@
       "website": "http://xregexp.com"
     },
     "XWiki": {
-      "cats": [
-        8
-      ],
+      "cats": [8],
       "excludes": "MediaWiki",
-      "html": [
-        "<html[^>]data-xwiki-[^>]>"
-      ],
+      "html": ["<html[^>]data-xwiki-[^>]>"],
       "icon": "xwiki.png",
       "implies": "Java\\;confidence:99",
       "meta": {
@@ -12371,17 +9867,13 @@
       "website": "http://www.xwiki.org"
     },
     "Xajax": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Xajax.png",
       "script": "xajax_core.*\\.js",
       "website": "http://xajax-project.org"
     },
     "Xanario": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Xanario.png",
       "meta": {
         "generator": "xanario shopsoftware"
@@ -12389,9 +9881,7 @@
       "website": "http://xanario.de"
     },
     "XenForo": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "cookies": {
         "xf_csrf": "",
         "xf_session": ""
@@ -12401,35 +9891,26 @@
         "<html id=\"XF\" "
       ],
       "icon": "XenForo.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "js": {
         "XF.GuestUsername": ""
       },
       "website": "http://xenforo.com"
     },
     "Xeora": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "Server": "XeoraEngine",
         "X-Powered-By": "XeoraCube"
       },
       "html": "<input type=\"hidden\" name=\"_sys_bind_\\d+\" id=\"_sys_bind_\\d+\" />",
-      "implies": [
-        "Microsoft ASP.NET"
-      ],
+      "implies": ["Microsoft ASP.NET"],
       "icon": "xeora.png",
       "script": "/_bi_sps_v.+\\.js",
       "website": "http://www.xeora.org"
     },
     "Xitami": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Xitami(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -12437,9 +9918,7 @@
       "website": "http://xitami.com"
     },
     "Xonic": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": [
         "Powered by <a href=\"http://www\\.xonic-solutions\\.de/index\\.php\" target=\"_blank\">xonic-solutions Shopsoftware</a>"
       ],
@@ -12451,9 +9930,7 @@
       "website": "http://www.xonic-solutions.de"
     },
     "XpressEngine": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "XpressEngine.png",
       "meta": {
         "generator": "XpressEngine"
@@ -12461,9 +9938,7 @@
       "website": "http://www.xpressengine.com/"
     },
     "YUI": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "YUI.png",
       "js": {
         "YAHOO.VERSION": "^(.+)$\\;version:\\1",
@@ -12473,25 +9948,19 @@
       "website": "http://yuilibrary.com"
     },
     "YUI Doc": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "html": "(?:<html[^>]* yuilibrary\\.com/rdf/[\\d.]+/yui\\.rdf|<body[^>]+class=\"yui3-skin-sam)",
       "icon": "yahoo.png",
       "website": "http://developer.yahoo.com/yui/yuidoc"
     },
     "YaBB": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "html": "Powered by <a href=\"[^>]+yabbforum",
       "icon": "YaBB.png",
       "website": "http://www.yabbforum.com"
     },
     "Yahoo Advertising": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": [
         "<iframe[^>]+adserver\\.yahoo\\.com",
         "<img[^>]+clicks\\.beap\\.bc\\.yahoo\\.com"
@@ -12504,9 +9973,7 @@
       "website": "http://advertising.yahoo.com"
     },
     "Yahoo! Ecommerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-XRDS-Location": "/ystore/"
       },
@@ -12518,18 +9985,14 @@
       "website": "http://smallbusiness.yahoo.com/ecommerce"
     },
     "Yahoo! Tag Manager": {
-      "cats": [
-        42
-      ],
+      "cats": [42],
       "html": "<!-- (?:End )?Yahoo! Tag Manager -->",
       "script": "b\\.yjtag\\.jp/iframe",
       "icon": "yahoo.png",
       "website": "https://tagmanager.yahoo.co.jp/"
     },
     "Yahoo! Web Analytics": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "yahoo.png",
       "js": {
         "YWA": ""
@@ -12538,9 +10001,7 @@
       "website": "http://web.analytics.yahoo.com"
     },
     "Yandex.Direct": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": "<yatag class=\"ya-partner__ads\">",
       "icon": "Yandex.Direct.png",
       "js": {
@@ -12551,9 +10012,7 @@
       "website": "http://partner.yandex.com"
     },
     "Yandex.Metrika": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "Yandex.Metrika.png",
       "js": {
         "yandex_metrika": ""
@@ -12565,30 +10024,22 @@
       "website": "http://metrika.yandex.com"
     },
     "Yaws": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "Yaws(?: ([\\d.]+))?\\;version:\\1"
       },
       "icon": "Yaws.png",
-      "implies": [
-        "Erlang"
-      ],
+      "implies": ["Erlang"],
       "website": "http://yaws.hyber.org"
     },
     "Yieldlab": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "icon": "Yieldlab.png",
       "script": "^https?://(?:[^/]+\\.)?yieldlab\\.net/",
       "website": "http://yieldlab.de"
     },
     "Yii": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "cookies": {
         "YII_CSRF_TOKEN": ""
       },
@@ -12598,9 +10049,7 @@
         "<!\\[CDATA\\[YII-BLOCK-(?:HEAD|BODY-BEGIN|BODY-END)\\]"
       ],
       "icon": "Yii.png",
-      "implies": [
-        "PHP"
-      ],
+      "implies": ["PHP"],
       "script": [
         "/assets/[a-zA-Z0-9]{8}\\/yii\\.js$",
         "/yii\\.(?:validation|activeForm)\\.js"
@@ -12608,9 +10057,7 @@
       "website": "https://www.yiiframework.com"
     },
     "Yoast SEO": {
-      "cats": [
-        54
-      ],
+      "cats": [54],
       "html": [
         "<!-- This site is optimized with the Yoast (?:WordPress )?SEO plugin v([\\d.]+) -\\;version:\\1"
       ],
@@ -12619,20 +10066,14 @@
       "website": "http://yoast.com"
     },
     "WP-Statistics": {
-      "cats": [
-        10
-      ],
-      "html": [
-        "<!-- Analytics by WP-Statistics v([\\d.]+) -\\;version:\\1"
-      ],
+      "cats": [10],
+      "html": ["<!-- Analytics by WP-Statistics v([\\d.]+) -\\;version:\\1"],
       "icon": "WP-Statistics.png",
       "implies": "WordPress",
       "website": "https://wp-statistics.com"
     },
     "YouTrack": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "html": [
         "no-title=\"YouTrack\">",
         "data-reactid=\"[^\"]+\">youTrack ([0-9.]+)<\\;version:\\1",
@@ -12642,22 +10083,14 @@
       "website": "http://www.jetbrains.com/youtrack/"
     },
     "YouTube": {
-      "cats": [
-        14
-      ],
+      "cats": [14],
       "html": "<(?:param|embed|iframe)[^>]+youtube(?:-nocookie)?\\.com/(?:v|embed)",
       "icon": "YouTube.png",
       "website": "http://www.youtube.com"
     },
     "iEXExchanger": {
-      "cats": [
-        1
-      ],
-      "implies": [
-        "PHP",
-        "Apache",
-        "Angular"
-      ],
+      "cats": [1],
+      "implies": ["PHP", "Apache", "Angular"],
       "cookies": {
         "iexexchanger_session": ""
       },
@@ -12668,9 +10101,7 @@
       "website": "https://exchanger.iexbase.com"
     },
     "ZK": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "html": "<!-- ZK [.\\d\\s]+-->",
       "icon": "ZK.png",
       "implies": "Java",
@@ -12678,9 +10109,7 @@
       "website": "http://zkoss.org"
     },
     "ZURB Foundation": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": [
         "<link[^>]+foundation[^>\"]+css",
         "<div [^>]*class=\"[^\"]*(?:small|medium|large)-\\d{1,2} columns"
@@ -12692,9 +10121,7 @@
       "website": "http://foundation.zurb.com"
     },
     "Zabbix": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "<body[^>]+zbxCallPostScripts",
       "icon": "Zabbix.png",
       "implies": "PHP",
@@ -12708,9 +10135,7 @@
       "website": "http://zabbix.com"
     },
     "Zanox": {
-      "cats": [
-        36
-      ],
+      "cats": [36],
       "html": "<img [^>]*src=\"[^\"]+ad\\.zanox\\.com",
       "icon": "Zanox.png",
       "js": {
@@ -12720,9 +10145,7 @@
       "website": "http://zanox.com"
     },
     "Zen Cart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Zen Cart.png",
       "meta": {
         "generator": "Zen Cart"
@@ -12730,9 +10153,7 @@
       "website": "http://www.zen-cart.com"
     },
     "Zend": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cookies": {
         "ZENDSERVERSESSID": ""
       },
@@ -12743,19 +10164,13 @@
       "website": "http://zend.com"
     },
     "Zendesk Chat": {
-      "cats": [
-        52
-      ],
+      "cats": [52],
       "icon": "Zendesk Chat.png",
       "script": "v2\\.zopim\\.com",
       "website": "http://zopim.com"
     },
     "Zendesk": {
-      "cats": [
-        1,
-        52,
-        61
-      ],
+      "cats": [1, 52, 61],
       "headers": {
         "x-zendesk-user-id": ""
       },
@@ -12768,9 +10183,7 @@
       "website": "https://zendesk.com"
     },
     "Zenfolio": {
-      "cats": [
-        7
-      ],
+      "cats": [7],
       "icon": "Zenfolio.png",
       "js": {
         "Zenfolio": ""
@@ -12778,9 +10191,7 @@
       "website": "https://zenfolio.com"
     },
     "Zepto": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "Zepto.png",
       "js": {
         "Zepto": ""
@@ -12789,9 +10200,7 @@
       "website": "http://zeptojs.com"
     },
     "Zeuscart": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<form name=\"product\" method=\"post\" action=\"[^\"]+\\?do=addtocart&prodid=\\d+\"(?!<\\/form>.)+<input type=\"hidden\" name=\"addtocart\" value=\"\\d+\">",
       "icon": "Zeuscart.png",
       "implies": "PHP",
@@ -12799,9 +10208,7 @@
       "website": "http://zeuscart.com"
     },
     "Zimbra": {
-      "cats": [
-        30
-      ],
+      "cats": [30],
       "icon": "Zimbra.png",
       "cookies": {
         "ZM_TEST": "true"
@@ -12811,9 +10218,7 @@
       "website": "https://www.zimbra.com/"
     },
     "Zinnia": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "icon": "Zinnia.png",
       "implies": "Django",
       "meta": {
@@ -12822,18 +10227,14 @@
       "website": "http://django-blog-zinnia.com"
     },
     "Zone.js": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "js": {
         "Zone.root": ""
       },
       "website": "https://github.com/angular/zone.js/"
     },
     "Zope": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "^Zope/"
       },
@@ -12841,9 +10242,7 @@
       "website": "http://zope.org"
     },
     "a-blog cms": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "a-blog cms.svg",
       "implies": "PHP",
       "meta": {
@@ -12852,10 +10251,7 @@
       "website": "http://www.a-blogcms.jp"
     },
     "actionhero.js": {
-      "cats": [
-        18,
-        22
-      ],
+      "cats": [18, 22],
       "headers": {
         "X-Powered-By": "actionhero API"
       },
@@ -12868,9 +10264,7 @@
       "website": "http://www.actionherojs.com"
     },
     "amCharts": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "amCharts.png",
       "js": {
         "AmCharts": ""
@@ -12879,18 +10273,14 @@
       "website": "http://amcharts.com"
     },
     "animate.css": {
-      "cats": [
-        66
-      ],
+      "cats": [66],
       "html": [
         "<link [^>]+(?:/([\\d.]+)/)?animate\\.(?:min\\.)?css\\;version:\\1"
       ],
       "website": "https://daneden.github.io/animate.css/"
     },
     "basket.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "basket.js.png",
       "js": {
         "basket.isValidItem": ""
@@ -12899,9 +10289,7 @@
       "website": "https://addyosmani.github.io/basket.js/"
     },
     "cPanel": {
-      "cats": [
-        9
-      ],
+      "cats": [9],
       "headers": {
         "Server": "cpsrvd/([\\d.]+)\\;version:\\1"
       },
@@ -12914,9 +10302,7 @@
       "website": "http://www.cpanel.net"
     },
     "cgit": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": [
         "<[^>]+id='cgit'",
         "generated by <a href='http://git\\.zx2c4\\.com/cgit/about/'>cgit v([\\d.a-z-]+)</a>\\;version:\\1"
@@ -12929,9 +10315,7 @@
       "website": "http://git.zx2c4.com/cgit"
     },
     "comScore": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "html": "<iframe[^>]* (?:id=\"comscore\"|scr=[^>]+comscore)|\\.scorecardresearch\\.com/beacon\\.js|COMSCORE\\.beacon",
       "icon": "comScore.png",
       "js": {
@@ -12942,9 +10326,7 @@
       "website": "http://comscore.com"
     },
     "debut": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "debut\\/?([\\d\\.]+)?\\;version:\\1"
       },
@@ -12953,9 +10335,7 @@
       "website": "http://www.brother.com"
     },
     "deepMiner": {
-      "cats": [
-        56
-      ],
+      "cats": [56],
       "icon": "deepminer.png",
       "js": {
         "deepMiner": ""
@@ -12964,9 +10344,7 @@
       "website": "https://github.com/deepwn/deepMiner"
     },
     "e107": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "e107_tz": ""
       },
@@ -12979,9 +10357,7 @@
       "website": "http://e107.org"
     },
     "eSyndiCat": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Drectory-Script": "^eSyndiCat"
       },
@@ -12996,10 +10372,7 @@
       "website": "http://esyndicat.com"
     },
     "eZ Platform": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "icon": "eZ.svg",
       "implies": "Symfony",
       "meta": {
@@ -13008,10 +10381,7 @@
       "website": "https://ezplatform.com/"
     },
     "eZ Publish": {
-      "cats": [
-        1,
-        6
-      ],
+      "cats": [1, 6],
       "cookies": {
         "eZSESSID": ""
       },
@@ -13026,9 +10396,7 @@
       "website": "https://github.com/ezsystems/ezpublish-legacy"
     },
     "ef.js": {
-      "cats": [
-        12
-      ],
+      "cats": [12],
       "icon": "ef.js.svg",
       "js": {
         "ef.version": "^(.+)$\\;version:\\1",
@@ -13038,9 +10406,7 @@
       "website": "http://ef.js.org"
     },
     "enduro.js": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "^enduro\\.js"
       },
@@ -13049,9 +10415,7 @@
       "website": "http://endurojs.com"
     },
     "git": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "cpe": "cpe:/a:git-scm:git",
       "icon": "git.svg",
       "meta": {
@@ -13060,27 +10424,17 @@
       "website": "http://git-scm.com"
     },
     "gitlist": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "cpe": "cpe:/a:gitlist:gitlist",
       "html": "<p>Powered by <a[^>]+>GitList ([\\d.]+)\\;version:\\1",
-      "implies": [
-        "PHP",
-        "git"
-      ],
+      "implies": ["PHP", "git"],
       "website": "http://gitlist.org"
     },
     "gitweb": {
-      "cats": [
-        47
-      ],
+      "cats": [47],
       "html": "<!-- git web interface version ([\\d.]+)?\\;version:\\1",
       "icon": "git.svg",
-      "implies": [
-        "Perl",
-        "git"
-      ],
+      "implies": ["Perl", "git"],
       "meta": {
         "generator": "gitweb(?:/([\\d.]+\\d))?\\;version:\\1"
       },
@@ -13088,22 +10442,16 @@
       "website": "http://git-scm.com"
     },
     "govCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "govCMS.svg",
-      "implies": [
-        "Drupal"
-      ],
+      "implies": ["Drupal"],
       "meta": {
         "generator": "Drupal ([\\d]+) \\(http:\\/\\/drupal\\.org\\) \\+ govCMS\\;version:\\1"
       },
       "website": "https://www.govcms.gov.au"
     },
     "gunicorn": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "gunicorn(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -13112,9 +10460,7 @@
       "website": "http://gunicorn.org"
     },
     "iCongo": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "Hybris.png",
       "implies": "Adobe ColdFusion",
       "meta": {
@@ -13123,23 +10469,16 @@
       "website": "http://hybris.com/icongo"
     },
     "iPresta": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "iPresta.png",
-      "implies": [
-        "PHP",
-        "PrestaShop"
-      ],
+      "implies": ["PHP", "PrestaShop"],
       "meta": {
         "designer": "iPresta"
       },
       "website": "http://ipresta.ir"
     },
     "iWeb": {
-      "cats": [
-        20
-      ],
+      "cats": [20],
       "icon": "iWeb.png",
       "meta": {
         "generator": "^iWeb( [\\d.]+)?\\;version:\\1"
@@ -13147,9 +10486,7 @@
       "website": "http://apple.com/ilife/iweb"
     },
     "ikiwiki": {
-      "cats": [
-        8
-      ],
+      "cats": [8],
       "html": [
         "<link rel=\"alternate\" type=\"application/x-wiki\" title=\"Edit this page\" href=\"[^\"]*/ikiwiki\\.cgi",
         "<a href=\"/(?:cgi-bin/)?ikiwiki\\.cgi\\?do="
@@ -13158,9 +10495,7 @@
       "website": "http://ikiwiki.info"
     },
     "imperia CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<imp:live-info sysid=\"[0-9a-f-]+\"(?: node_id=\"[0-9/]*\")? *\\/>",
       "icon": "imperiaCMS.svg",
       "implies": "Perl",
@@ -13172,9 +10507,7 @@
       "website": "https://www.pirobase-imperia.com/de/produkte/produktuebersicht/imperia-cms"
     },
     "io4 CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "io4 CMS.png",
       "meta": {
         "generator": "GO[ |]+CMS Enterprise"
@@ -13182,9 +10515,7 @@
       "website": "http://notenbomer.nl/Producten/Content_management/io4_|_cms"
     },
     "ip-label": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "icon": "iplabel.svg",
       "js": {
         "clobs": ""
@@ -13193,9 +10524,7 @@
       "website": "http://www.ip-label.com"
     },
     "jQTouch": {
-      "cats": [
-        26
-      ],
+      "cats": [26],
       "icon": "jQTouch.png",
       "js": {
         "jQT": ""
@@ -13204,9 +10533,7 @@
       "website": "http://jqtouch.com"
     },
     "jQuery": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "jQuery.svg",
       "js": {
         "jQuery.fn.jquery": "([\\d.]+)\\;version:\\1"
@@ -13219,9 +10546,7 @@
       "website": "https://jquery.com"
     },
     "jQuery Migrate": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "jQuery.svg",
       "implies": "jQuery",
       "js": {
@@ -13233,9 +10558,7 @@
       "website": "https://github.com/jquery/jquery-migrate"
     },
     "jQuery Mobile": {
-      "cats": [
-        26
-      ],
+      "cats": [26],
       "icon": "jQuery Mobile.svg",
       "implies": "jQuery",
       "js": {
@@ -13245,9 +10568,7 @@
       "website": "https://jquerymobile.com"
     },
     "jQuery-pjax": {
-      "cats": [
-        26
-      ],
+      "cats": [26],
       "implies": "jQuery",
       "meta": {
         "pjax-timeout": "",
@@ -13262,17 +10583,13 @@
       "website": "https://github.com/defunkt/jquery-pjax"
     },
     "jQuery Sparklines": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "implies": "jQuery",
       "script": "jquery\\.sparkline.*\\.js",
       "website": "http://omnipotent.net/jquery.sparkline/"
     },
     "jQuery UI": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "jQuery UI.svg",
       "implies": "jQuery",
       "js": {
@@ -13286,31 +10603,23 @@
       "website": "http://jqueryui.com"
     },
     "jqPlot": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "jqPlot.png",
       "implies": "jQuery",
       "script": "jqplot.*\\.js",
       "website": "http://www.jqplot.com"
     },
     "Kinsta": {
-      "cats": [
-        62
-      ],
+      "cats": [62],
       "headers": {
         "x-kinsta-cache": ""
       },
-      "implies": [
-        "WordPress"
-      ],
+      "implies": ["WordPress"],
       "icon": "kinsta.svg",
       "website": "https://kinsta.com"
     },
     "libwww-perl-daemon": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "libwww-perl-daemon(?:/([\\d\\.]+))?\\;version:\\1"
       },
@@ -13319,9 +10628,7 @@
       "website": "http://metacpan.org/pod/HTTP::Daemon"
     },
     "lighttpd": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "lighttpd(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -13329,9 +10636,7 @@
       "website": "http://www.lighttpd.net"
     },
     "math.js": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "math.js.png",
       "js": {
         "mathjs": ""
@@ -13340,9 +10645,7 @@
       "website": "http://mathjs.org"
     },
     "mini_httpd": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "mini_httpd(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -13350,9 +10653,7 @@
       "website": "http://acme.com/software/mini_httpd"
     },
     "mod_auth_pam": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "headers": {
         "Server": "mod_auth_pam(?:/([\\d\\.]+))?\\;version:\\1"
       },
@@ -13361,9 +10662,7 @@
       "website": "http://pam.sourceforge.net/mod_auth_pam"
     },
     "mod_dav": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "headers": {
         "Server": "\\b(?:mod_)?DAV\\b(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -13372,9 +10671,7 @@
       "website": "http://webdav.org/mod_dav"
     },
     "mod_fastcgi": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "headers": {
         "Server": "mod_fastcgi(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -13383,81 +10680,54 @@
       "website": "http://www.fastcgi.com/mod_fastcgi/docs/mod_fastcgi.html"
     },
     "mod_jk": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "headers": {
         "Server": "mod_jk(?:/([\\d\\.]+))?\\;version:\\1"
       },
       "icon": "Apache.svg",
-      "implies": [
-        "Apache Tomcat",
-        "Apache"
-      ],
+      "implies": ["Apache Tomcat", "Apache"],
       "website": "http://tomcat.apache.org/tomcat-3.3-doc/mod_jk-howto.html"
     },
     "mod_perl": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "headers": {
         "Server": "mod_perl(?:/([\\d\\.]+))?\\;version:\\1"
       },
       "icon": "mod_perl.png",
-      "implies": [
-        "Perl",
-        "Apache"
-      ],
+      "implies": ["Perl", "Apache"],
       "website": "http://perl.apache.org"
     },
     "mod_python": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "headers": {
         "Server": "mod_python(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "mod_python.png",
-      "implies": [
-        "Python",
-        "Apache"
-      ],
+      "implies": ["Python", "Apache"],
       "website": "http://www.modpython.org"
     },
     "mod_rack": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "headers": {
         "Server": "mod_rack(?:/([\\d.]+))?\\;version:\\1",
         "X-Powered-By": "mod_rack(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "Phusion Passenger.png",
-      "implies": [
-        "Ruby on Rails\\;confidence:50",
-        "Apache"
-      ],
+      "implies": ["Ruby on Rails\\;confidence:50", "Apache"],
       "website": "http://phusionpassenger.com"
     },
     "mod_rails": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "headers": {
         "Server": "mod_rails(?:/([\\d.]+))?\\;version:\\1",
         "X-Powered-By": "mod_rails(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "Phusion Passenger.png",
-      "implies": [
-        "Ruby on Rails\\;confidence:50",
-        "Apache"
-      ],
+      "implies": ["Ruby on Rails\\;confidence:50", "Apache"],
       "website": "http://phusionpassenger.com"
     },
     "mod_ssl": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "headers": {
         "Server": "mod_ssl(?:/([\\d.]+))?\\;version:\\1"
       },
@@ -13466,24 +10736,17 @@
       "website": "http://modssl.org"
     },
     "mod_wsgi": {
-      "cats": [
-        33
-      ],
+      "cats": [33],
       "headers": {
         "Server": "mod_wsgi(?:/([\\d.]+))?\\;version:\\1",
         "X-Powered-By": "mod_wsgi(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "mod_wsgi.png",
-      "implies": [
-        "Python\\;confidence:50",
-        "Apache"
-      ],
+      "implies": ["Python\\;confidence:50", "Apache"],
       "website": "https://code.google.com/p/modwsgi"
     },
     "nopCommerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "Nop.customer": ""
       },
@@ -13496,9 +10759,7 @@
       "website": "http://www.nopcommerce.com"
     },
     "openEngine": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "openEngine.png",
       "meta": {
         "openEngine": ""
@@ -13506,17 +10767,13 @@
       "website": "http://openengine.de/html/pages/de/"
     },
     "osCSS": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<body onload=\"window\\.defaultStatus='oscss templates';\"",
       "icon": "osCSS.png",
       "website": "http://www.oscss.org"
     },
     "osCommerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "cookies": {
         "osCsid": ""
       },
@@ -13526,30 +10783,20 @@
         "<(?:tr|td|table)class=\"[^\"]*infoBoxHeading"
       ],
       "icon": "osCommerce.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "website": "https://www.oscommerce.com"
     },
     "osTicket": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "cookies": {
         "OSTSESSID": ""
       },
       "icon": "osTicket.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "website": "http://osticket.com"
     },
     "otrs": {
-      "cats": [
-        13
-      ],
+      "cats": [13],
       "html": "<!--\\s+OTRS: Copyright \\d+-\\d+, OTRS AG",
       "icon": "otrs.png",
       "implies": "Perl",
@@ -13557,9 +10804,7 @@
       "website": "https://www.otrs.com"
     },
     "ownCloud": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "html": "<a href=\"https://owncloud\\.com\" target=\"_blank\">ownCloud Inc\\.</a><br/>Your Cloud, Your Data, Your Way!",
       "icon": "ownCloud.png",
       "implies": "PHP",
@@ -13569,18 +10814,14 @@
       "website": "https://owncloud.org"
     },
     "papaya CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": "<link[^>]*/papaya-themes/",
       "icon": "papaya CMS.png",
       "implies": "PHP",
       "website": "https://papaya-cms.com"
     },
     "particles.js": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "html": "<div id=\"particles-js\">",
       "js": {
         "particlesJS": ""
@@ -13589,35 +10830,25 @@
       "website": "https://vincentgarreau.com/particles.js/"
     },
     "PhotoShelter": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": [
         "<!--\\s+#+ Powered by the PhotoShelter Beam platform",
         "<link[^>]+c\\.photoshelter\\.com"
       ],
       "url": "photoshelter\\.com",
-      "implies": [
-        "PHP",
-        "MySQL",
-        "jQuery"
-      ],
+      "implies": ["PHP", "MySQL", "jQuery"],
       "icon": "PhotoShelter.png",
       "website": "https://www.photoshelter.com"
     },
     "phpAlbum": {
-      "cats": [
-        7
-      ],
+      "cats": [7],
       "html": "<!--phpalbum ([.\\d\\s]+)-->\\;version:\\1",
       "icon": "phpAlbum.png",
       "implies": "PHP",
       "website": "http://phpalbum.net"
     },
     "phpBB": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "cookies": {
         "phpbb": ""
       },
@@ -13640,9 +10871,7 @@
       "website": "https://phpbb.com"
     },
     "phpCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "phpCMS.png",
       "implies": "PHP",
       "js": {
@@ -13651,73 +10880,51 @@
       "website": "http://phpcms.de"
     },
     "phpDocumentor": {
-      "cats": [
-        4
-      ],
+      "cats": [4],
       "html": "<!-- Generated by phpDocumentor",
       "icon": "phpDocumentor.png",
       "implies": "PHP",
       "website": "https://www.phpdoc.org"
     },
     "phpMyAdmin": {
-      "cats": [
-        3
-      ],
+      "cats": [3],
       "html": "(?: \\| phpMyAdmin ([\\d.]+)<\\/title>|PMA_sendHeaderLocation\\(|<link [^>]*href=\"[^\"]*phpmyadmin\\.css\\.php)\\;version:\\1",
       "icon": "phpMyAdmin.png",
-      "implies": [
-        "PHP",
-        "MySQL"
-      ],
+      "implies": ["PHP", "MySQL"],
       "js": {
         "pma_absolute_uri": ""
       },
       "website": "https://www.phpmyadmin.net"
     },
     "phpPgAdmin": {
-      "cats": [
-        3
-      ],
+      "cats": [3],
       "html": "(?:<title>phpPgAdmin</title>|<span class=\"appname\">phpPgAdmin)",
       "icon": "phpPgAdmin.png",
       "implies": "PHP",
       "website": "http://phppgadmin.sourceforge.net"
     },
     "phpSQLiteCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "phpSQLiteCMS.png",
-      "implies": [
-        "PHP",
-        "SQLite"
-      ],
+      "implies": ["PHP", "SQLite"],
       "meta": {
         "generator": "^phpSQLiteCMS(?: (.+))?$\\;version:\\1"
       },
       "website": "http://phpsqlitecms.net"
     },
     "phpliteadmin": {
-      "cats": [
-        3
-      ],
+      "cats": [3],
       "html": [
         "<span id='logo'>phpLiteAdmin</span> <span id='version'>v([0-9.]+)<\\;version:\\1",
         "<!-- Copyright [0-9]+ phpLiteAdmin (?:https?://www\\.phpliteadmin\\.org/) -->",
         "Powered by <a href='https?://www\\.phpliteadmin\\.org/'"
       ],
       "icon": "phpliteadmin.png",
-      "implies": [
-        "PHP",
-        "SQLite"
-      ],
+      "implies": ["PHP", "SQLite"],
       "website": "https://www.phpliteadmin.org/"
     },
     "phpwind": {
-      "cats": [
-        1,
-        2
-      ],
+      "cats": [1, 2],
       "html": "(?:Powered|Code) by <a href=\"[^\"]+phpwind\\.net",
       "icon": "phpwind.png",
       "implies": "PHP",
@@ -13727,9 +10934,7 @@
       "website": "https://www.phpwind.net"
     },
     "pirobase CMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "html": [
         "<(?:script|link)[^>]/site/[a-z0-9/._-]+/resourceCached/[a-z0-9/._-]+",
         "<input[^>]+cbi:///cms/"
@@ -13739,9 +10944,7 @@
       "website": "https://www.pirobase-imperia.com/de/produkte/produktuebersicht/pirobase-cms"
     },
     "prettyPhoto": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "html": "(?:<link [^>]*href=\"[^\"]*prettyPhoto(?:\\.min)?\\.css|<a [^>]*rel=\"prettyPhoto)",
       "icon": "prettyPhoto.png",
       "implies": "jQuery",
@@ -13755,9 +10958,7 @@
       "website": "http://no-margin-for-errors.com/projects/prettyphoto-jquery-lightbox-clone/"
     },
     "punBB": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "js": {
         "PUNBB": ""
       },
@@ -13767,9 +10968,7 @@
       "website": "http://punbb.informer.com"
     },
     "reCAPTCHA": {
-      "cats": [
-        16
-      ],
+      "cats": [16],
       "html": [
         "<div[^>]+id=\"recaptcha_image",
         "<link[^>]+recaptcha",
@@ -13788,31 +10987,20 @@
       "website": "https://www.google.com/recaptcha/"
     },
     "sIFR": {
-      "cats": [
-        17
-      ],
+      "cats": [17],
       "icon": "sIFR.png",
       "script": "sifr\\.js",
       "website": "https://www.mikeindustries.com/blog/sifr"
     },
     "Siteglide": {
-      "cats": [
-        1,
-        61,
-        53,
-        6
-      ],
+      "cats": [1, 61, 53, 6],
       "icon": "Siteglide.svg",
       "script": "siteglide\\.js",
       "website": "https://www.siteglide.com",
-      "implies": [
-        "PlatformOS"
-      ]
+      "implies": ["PlatformOS"]
     },
     "sNews": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "sNews.png",
       "meta": {
         "generator": "sNews"
@@ -13820,9 +11008,7 @@
       "website": "https://snewscms.com"
     },
     "script.aculo.us": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "script.aculo.us.png",
       "js": {
         "Scriptaculous.Version": "^(.+)$\\;version:\\1"
@@ -13831,9 +11017,7 @@
       "website": "https://script.aculo.us"
     },
     "scrollreveal": {
-      "cats": [
-        59
-      ],
+      "cats": [59],
       "icon": "scrollreveal.svg",
       "html": "<[^>]+data-sr(?:-id)",
       "js": {
@@ -13843,9 +11027,7 @@
       "website": "https://scrollrevealjs.org"
     },
     "shine.js": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "js": {
         "Shine": ""
       },
@@ -13853,28 +11035,21 @@
       "website": "https://bigspaceship.github.io/shine.js/"
     },
     "styled-components": {
-      "cats": [
-        12,
-        47
-      ],
+      "cats": [12, 47],
       "html": [
         "<style[^>]*data-styled(?:-components)?[\\s\"]",
         "<style[^>]+data-styled-version=\"([0-9]+)\"\\;version:\\1",
         "<[^>]+sc-component-id: sc-"
       ],
       "icon": "styled-components.png",
-      "implies": [
-        "React"
-      ],
+      "implies": ["React"],
       "js": {
         "styled": ""
       },
       "website": "https://styled-components.com"
     },
     "swift.engine": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "headers": {
         "X-Powered-By": "swift\\.engine"
       },
@@ -13882,9 +11057,7 @@
       "website": "http://mittec.ru/default"
     },
     "three.js": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "icon": "three.js.png",
       "js": {
         "THREE.REVISION": "^(.+)$\\;version:\\1"
@@ -13893,9 +11066,7 @@
       "website": "https://threejs.org"
     },
     "thttpd": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "cpe": "cpe:/a:acme:thttpd",
       "headers": {
         "Server": "\\bthttpd(?:/([\\d.]+))?\\;version:\\1"
@@ -13904,9 +11075,7 @@
       "website": "https://acme.com/software/thttpd"
     },
     "total.js": {
-      "cats": [
-        18
-      ],
+      "cats": [18],
       "headers": {
         "X-Powered-By": "^total\\.js"
       },
@@ -13915,9 +11084,7 @@
       "website": "https://totaljs.com"
     },
     "uCoz": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cookies": {
         "uCoz": ""
       },
@@ -13925,11 +11092,7 @@
       "website": "https://ucoz.ru"
     },
     "uKnowva": {
-      "cats": [
-        1,
-        2,
-        50
-      ],
+      "cats": [1, 2, 50],
       "headers": {
         "X-Content-Encoded-By": "uKnowva ([\\d.]+)\\;version:\\1"
       },
@@ -13943,9 +11106,7 @@
       "website": "https://uknowva.com"
     },
     "vBulletin": {
-      "cats": [
-        2
-      ],
+      "cats": [2],
       "cpe": "cpe:/a:vbulletin:vbulletin",
       "html": "<div id=\"copyright\">Powered by vBulletin",
       "icon": "vBulletin.png",
@@ -13964,9 +11125,7 @@
       "website": "https://www.vbulletin.com"
     },
     "vibecommerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "excludes": "PrestaShop",
       "icon": "vibecommerce.png",
       "implies": "PHP",
@@ -13977,9 +11136,7 @@
       "website": "http://vibecommerce.com.br"
     },
     "Virgool": {
-      "cats": [
-        11
-      ],
+      "cats": [11],
       "headers": {
         "X-Powered-By": "^Virgool$"
       },
@@ -13988,9 +11145,7 @@
       "website": "https://virgool.io"
     },
     "shoperfa": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "headers": {
         "X-Powered-By": "^Shoperfa$"
       },
@@ -13999,9 +11154,7 @@
       "website": "https://shoperfa.com"
     },
     "webEdition": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "cpe": "cpe:/a:webedition:webedition_cms",
       "icon": "webEdition.png",
       "meta": {
@@ -14011,9 +11164,7 @@
       "website": "http://webedition.de/en"
     },
     "webpack": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "webpack.svg",
       "js": {
         "webpackJsonp": ""
@@ -14021,9 +11172,7 @@
       "website": "https://webpack.js.org/"
     },
     "wisyCMS": {
-      "cats": [
-        1
-      ],
+      "cats": [1],
       "icon": "wisyCMS.svg",
       "meta": {
         "generator": "^wisy CMS[ v]{0,3}([0-9.,]*)\\;version:\\1"
@@ -14031,9 +11180,7 @@
       "website": "https://wisy.3we.de"
     },
     "parcel": {
-      "cats": [
-        19
-      ],
+      "cats": [19],
       "icon": "Parcel.png",
       "js": {
         "parcelRequire": ""
@@ -14041,18 +11188,13 @@
       "website": "https://parceljs.org/"
     },
     "wpCache": {
-      "cats": [
-        23
-      ],
+      "cats": [23],
       "headers": {
         "X-Powered-By": "wpCache(?:/([\\d.]+))?\\;version:\\1"
       },
       "html": "<!--[^>]+wpCache",
       "icon": "wpCache.png",
-      "implies": [
-        "WordPress",
-        "PHP"
-      ],
+      "implies": ["WordPress", "PHP"],
       "meta": {
         "generator": "wpCache",
         "keywords": "wpCache"
@@ -14061,9 +11203,7 @@
       "website": "https://wpcache.co"
     },
     "xCharts": {
-      "cats": [
-        25
-      ],
+      "cats": [25],
       "html": "<link[^>]* href=\"[^\"]*xcharts(?:\\.min)?\\.css",
       "implies": "D3",
       "js": {
@@ -14073,9 +11213,7 @@
       "website": "https://tenxer.github.io/xcharts/"
     },
     "xtCommerce": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "html": "<div class=\"copyright\">[^<]+<a[^>]+>xt:Commerce",
       "icon": "xtCommerce.png",
       "meta": {
@@ -14084,9 +11222,7 @@
       "website": "https://www.xt-commerce.com"
     },
     "Yepcomm": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "icon": "yepcomm.png",
       "meta": {
         "copyright": "Yepcomm Tecnologia",
@@ -14095,10 +11231,7 @@
       "website": "https://www.yepcomm.com.br"
     },
     "Halo": {
-      "cats": [
-        1,
-        11
-      ],
+      "cats": [1, 11],
       "icon": "Halo.svg",
       "meta": {
         "generator": "Halo ([\\d.]+)?\\;version:\\1"
@@ -14107,9 +11240,7 @@
       "website": "https://halo.run"
     },
     "Zipkin": {
-      "cats": [
-        10
-      ],
+      "cats": [10],
       "headers": {
         "X-B3-TraceId": "",
         "X-B3-SpanId": "",
@@ -14121,9 +11252,7 @@
       "website": "https://zipkin.io/"
     },
     "RX Web Server": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "X-Powered-By": "RX-WEB"
       },
@@ -14131,21 +11260,15 @@
       "website": "http://developers.rokitax.co.uk/projects/rxweb"
     },
     "Tencent Waterproof Wall": {
-      "cats": [
-        9
-      ],
+      "cats": [9],
       "icon": "TencentWaterproofWall.png",
       "script": "/TCaptcha\\.js",
       "website": "https://007.qq.com/"
     },
     "Saber": {
-      "cats": [
-        57
-      ],
+      "cats": [57],
       "icon": "Saber.svg",
-      "html": [
-        "<div [^>]*id=\"_saber\""
-      ],
+      "html": ["<div [^>]*id=\"_saber\""],
       "meta": {
         "generator": "^Saber v([\\d.]+)$\\;version:\\1"
       },
@@ -14153,9 +11276,7 @@
       "website": "https://saber.land/"
     },
     "GoCache": {
-      "cats": [
-        31
-      ],
+      "cats": [31],
       "headers": {
         "Server": "^gocache$",
         "X-GoCache-CacheStatus": ""
@@ -14164,9 +11285,7 @@
       "website": "https://www.gocache.com.br/"
     },
     "Litespeed Cache": {
-      "cats": [
-        23
-      ],
+      "cats": [23],
       "headers": {
         "x-litespeed-cache": ""
       },
@@ -14175,18 +11294,14 @@
       "website": "https://wordpress.org/plugins/litespeed-cache/"
     },
     "nghttpx - HTTP/2 proxy": {
-      "cats": [
-        22
-      ],
+      "cats": [22],
       "headers": {
         "Server": "nghttpx nghttp2/?([\\d.]+)?\\;version:\\1"
       },
       "website": "https://nghttp2.org"
     },
     "Onshop": {
-      "cats": [
-        6
-      ],
+      "cats": [6],
       "excludes": "OpenCart",
       "icon": "Onshop.svg",
       "implies": "PHP",
@@ -14197,9 +11312,7 @@
       "website": "https://onshop.asia"
     },
     "PageFly": {
-      "cats": [
-        51
-      ],
+      "cats": [51],
       "icon": "pagefly.png",
       "script": "pagefly\\.io",
       "website": "https://pagefly.io"


### PR DESCRIPTION
In December 2019, WP Engine added the `X-Powered-By: WP Engine` response header and removed the `wpe-backend: *` header.

I left the old headers in but can remove them if preferred.