### PR TITLE
Added X-Powered-By: WP Engine header

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -11800,7 +11800,8 @@
       "headers": {
         "wpe-backend": "",
         "X-Pass-Why": "",
-        "X-WPE-Loopback-Upstream-Addr": ""
+        "X-WPE-Loopback-Upstream-Addr": "",
+        "X-Powered-By": "WP Engine"
       },
       "icon": "wpengine.svg",
       "implies": "WordPress",


### PR DESCRIPTION
In December 2019, WP Engine added the `X-Powered-By: WP Engine` response header and removed the `wpe-backend: *` header.

I left the old headers in but can remove them if preferred.