### PR TITLE
October CMS detection fix

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -7590,7 +7590,7 @@
         1
       ],
       "cookies": {
-        "october_session=": ""
+        "october_session": ""
       },
       "icon": "October CMS.png",
       "implies": "Laravel",


### PR DESCRIPTION
The `October CMS` detection was not working due to a `=` in the cookie name. Now fixed.