### PR TITLE
Remove Implies Angular for Ionic

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5165,7 +5165,6 @@
         18
       ],
       "icon": "ionic.png",
-      "implies": "Angular",
       "js": {
         "Ionic.config": "",
         "Ionic.version": "^(.+)$\\;version:\\1"


### PR DESCRIPTION
Ionic moved from Angular component to [Web Component](https://ionicframework.com/#agnostic),
so Ionic app can be build with Angular, React, [Stencil](https://stenciljs.com/) (Web Component compiler) and soon Vuejs.

