### PR TITLE
Fix homepage link for `Catberry.js`

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1851,7 +1851,7 @@
         "catberry": "",
         "catberry.version": "^(.+)$\\;version:\\1"
       },
-      "website": "http://catberry.org"
+      "website": "https://catberry.github.io/"
     },
     "CentOS": {
       "cats": [


### PR DESCRIPTION
The custom domain is no longer available, the homepage has been moved to the GitHub pages.