### PR TITLE
Fix Hotjar script regex

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -4772,7 +4772,7 @@
         "HotleadController": "",
         "hj.apiUrlBase": ""
       },
-      "script": "^//static\\.hotjar\\.com/c/hotjar-",
+      "script": "//static\\.hotjar\\.com/c/hotjar-",
       "website": "https://www.hotjar.com"
     },
     "HubSpot": {


### PR DESCRIPTION
Remove the ^ token because somes site use full scheme