### PR TITLE
Link to documentation in README.md fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ technologies used on websites. It detects
 
 ## Documentation
 
-Please read the [developer documentation](https://www.wappalyzer.com/docs) to get started.
+Please read the [developer documentation](https://docs.wappalyzer.com/) to get started.


### PR DESCRIPTION
The current link (https://www.wappalyzer.com/docs) is no longer available. Shows a 404 not found.
![image](https://user-images.githubusercontent.com/16971163/78098709-c0ead600-73d7-11ea-8caa-4d4602334457.png)

This has been substituted with right link at https://docs.wappalyzer.com/
![image](https://user-images.githubusercontent.com/16971163/78098870-2b037b00-73d8-11ea-96e9-fa27176dab49.png)
