### PR TITLE
Fixed PHP.svg icon case for phpCMS

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -13374,7 +13374,7 @@
       "cats": [
         1
       ],
-      "icon": "php.svg",
+      "icon": "PHP.svg",
       "implies": "PHP",
       "js": {
         "phpcms": ""


### PR DESCRIPTION
`./run validate` is throwing the error because of the icon name case:

```
Validating icons...
/opt/wappalyzer/bin/validate-icons:45
				throw Error('Missing file for app "' + app + '": src/icons/' + iconPath);
				^

Error: Missing file for app "phpCMS": src/icons/php.svg
```