### PR TITLE
ZEIT changed its name to Vercel

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -7394,7 +7394,7 @@
       "headers": {
         "x-powered-by": "^Next\\.js ?([0-9.]+)?\\;version:\\1"
       },
-      "icon": "zeit.svg",
+      "icon": "vercel.svg",
       "implies": [
         "React",
         "webpack",
@@ -7454,18 +7454,18 @@
       "script": "^/nodebb\\.min\\.js\\?",
       "website": "https://nodebb.org"
     },
-    "Now": {
+    "Vercel": {
       "cats": [
         22
       ],
       "headers": {
         "server": "^now$",
         "x-now-trace": "",
-        "x-now-id": "",
-        "x-now-cache": ""
+        "x-vercel-id": "",
+        "x-vercel-cache": ""
       },
-      "icon": "zeit.svg",
-      "website": "https://zeit.co/now"
+      "icon": "vercel.svg",
+      "website": "https://vercel.com"
     },
     "OWL Carousel": {
       "cats": [

--- a/src/icons/vercel.svg
+++ b/src/icons/vercel.svg
@@ -1,0 +1,1 @@
+<svg width="116" height="100" viewBox="0 0 116 100" fill="#000" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M57.5 0L115 100H0L57.5 0z" /></svg>

--- a/src/icons/zeit.svg
+++ b/src/icons/zeit.svg
@@ -1,1 +1,0 @@
-<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><title>Zeit</title><desc>Created with Sketch.</desc><defs><linearGradient x1="100.686%" y1="181.283%" x2="41.808%" y2="100%" id="a"><stop stop-color="#fff" offset="0%"/><stop offset="100%"/></linearGradient></defs><path d="M15.766 3l14.766 26.134h-29.531z" fill-rule="nonzero" fill="url(#a)"/></svg>


### PR DESCRIPTION
(The company name and the product name are now unified, which makes the "Now" naming obsolete too.)  
  
`x-now-trace` seems to be unchanged.  
  
The SVG is taken from [the official page](https://vercel.com/design/vercel) and the only difference seems to be the fact that the very subtle gradient was removed.