### PR TITLE
Improves React script check

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -8868,7 +8868,7 @@
       "script": [
         "react(?:-with-addons)?[.-]([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
         "/([\\d.]+)/react(?:\\.min)?\\.js\\;version:\\1",
-        "react.*\\.js"
+        "^react\\.(?:production|development)?\\.*(?:min\\.)?js"
       ],
       "website": "https://reactjs.org"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -8868,7 +8868,7 @@
       "script": [
         "react(?:-with-addons)?[.-]([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
         "/([\\d.]+)/react(?:\\.min)?\\.js\\;version:\\1",
-        "^react\\.(?:production|development)?\\.*(?:min\\.)?js"
+        "react\\b.*\\.js"
       ],
       "website": "https://reactjs.org"
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -8868,7 +8868,7 @@
       "script": [
         "react(?:-with-addons)?[.-]([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
         "/([\\d.]+)/react(?:\\.min)?\\.js\\;version:\\1",
-        "react\\b.*\\.js"
+        "^react\\b.*\\.js"
       ],
       "website": "https://reactjs.org"
     },


### PR DESCRIPTION
I've been analyzing React usage via HTTP Archive + Wappalyzer and noticed a lot of false positives (sites that don't actually use React but show up in results).

They all seem to have something in common, a Google Adsense script that fails one of the script regex checks:

<pre>
pagead2.googlesyndication.com/.../<b>react</b>ive_library_fy2019.js
</pre>

Interestingly enough, many of these sites only include this script on mobile and not desktop. The Wappalyzer chrome extension doesn't seem to pick this inconsistency up, but this PR should fix this and improve the check :)