### PR TITLE
Fix "Developmentl" typo

### DIFF
--- a/src/drivers/webextension/_locales/en/messages.json
+++ b/src/drivers/webextension/_locales/en/messages.json
@@ -59,7 +59,7 @@
 	"categoryName42":           { "message": "Tag managers" },
 	"categoryName44":           { "message": "CI" },
 	"categoryName46":           { "message": "Remote Access" },
-	"categoryName47":           { "message": "Developmentl" },
+	"categoryName47":           { "message": "Development" },
 	"categoryName48":           { "message": "Network storage" },
 	"categoryName49":           { "message": "Feed readers" },
 	"categoryName50":           { "message": "DMS" },


### PR DESCRIPTION
This pull requests corrects the `Developmentl` category name to `Development`.