### PR TITLE
Fixed "Development tools" title

### DIFF
--- a/src/drivers/webextension/_locales/en/messages.json
+++ b/src/drivers/webextension/_locales/en/messages.json
@@ -59,7 +59,7 @@
 	"categoryName42":           { "message": "Tag managers" },
 	"categoryName44":           { "message": "CI" },
 	"categoryName46":           { "message": "Remote Access" },
-	"categoryName47":           { "message": "Developmentl" },
+	"categoryName47":           { "message": "Development tools" },
 	"categoryName48":           { "message": "Network storage" },
 	"categoryName49":           { "message": "Feed readers" },
 	"categoryName50":           { "message": "DMS" },


### PR DESCRIPTION
Fixed "Development tools" title.
I guess it was changed by mistake in https://github.com/AliasIO/wappalyzer/commit/a805ebce80e8dab0557cd99ded9fe81f078bcca2?diff=split#diff-75fc17dee8cff748956ba6bf20fbe85dR62

Screenshot:
![image](https://user-images.githubusercontent.com/6897234/81982089-e8b99480-9639-11ea-8ed8-38c796be0a75.png)
