### PR TITLE
Add Tailwind CSS identifier

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -10747,7 +10747,10 @@
       "cats": [
         66
       ],
-      "html": "<link[^>]+?href=\"[^\"]+tailwindcss(?:\\.min)?\\.css",
+      "html": [
+        "<link[^>]+?href=\"[^\"]+tailwindcss(?:\\.min)?\\.css",
+        "[^>]*class=\"[^\"]*(?:sm:|md:|lg:|xl:)"
+      ],
       "icon": "tailwindcss.svg",
       "website": "https://tailwindcss.com/"
     },


### PR DESCRIPTION
**Regex Expression**
`[^>]*class=\"[^\"]*(?:sm:|md:|lg:|xl:)`

The regex expression detects if there are any class names starting with either "sm:", "md:", "lg:", or "xl:" within the HTML. 

These class name prefixes are heavily used in websites using [Tailwind CSS](https://tailwindcss.com/), as they denote breakpoint styles.