### PR TITLE
Detect otrs version by X-Powered-By header

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -13468,6 +13468,9 @@
       "cats": [
         13
       ],
+      "headers": {
+        "X-Powered-By": "OTRS ([\\d.]+)\\;version:\\1"
+      },
       "html": "<!--\\s+OTRS: Copyright",
       "icon": "otrs.png",
       "implies": "Perl",


### PR DESCRIPTION
In most cases, the `X-Powered-By` header contains the version of OTRS.