### PR TITLE
Confidence level is not calculated for implied apps

### DIFF
--- a/src/wappalyzer.js
+++ b/src/wappalyzer.js
@@ -237,6 +237,15 @@ class Wappalyzer {
       resolveExcludes(apps, this.detected[url]);
       this.resolveImplies(apps, url.canonical);
 
+      // Resolve confidence again, required for implied apps
+      Object.keys(apps).forEach((appName) => {
+        const app = apps[appName];
+
+        if (!app.getConfidence()) {
+          delete apps[app.name];
+        }
+      });
+
       this.cacheDetectedApps(apps, url.canonical);
       this.trackDetectedApps(apps, url, language);
 


### PR DESCRIPTION
Issue: Implied apps always have confidence level 0. This does not seem like desired behaviour. If e.g. WordPress is detected with 100 confidence then PHP should also surely be detected with 100 confidence.

Looking into it, the function `app.getConfidence()` was being called BEFORE resolving implied apps. It never got called on the detected implied apps. I figured this must be an error, and it needs to be called again once the implied apps have been detected.

It's kinda messy running this twice on most apps and there may be a more elegant solution.