### PR TITLE
Improve Alpine.js detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -83,8 +83,14 @@
       "cats": [
         12
       ],
-      "html": "<[^>]+x-data[^<]+",
+      "html": "<[^>]+[^\\w-]x-data[^\\w-][^<]+\\;confidence:75",
+      "js": { 
+        "Alpine.version": "^(.+)$\\;version:\\1"
+      },
       "icon": "Alpine.js.png",
+      "script": [
+        "/alpine(?:\\.min)?\\.js"
+      ],
       "website": "https://github.com/alpinejs/alpine"
     },
     "AOLserver": {


### PR DESCRIPTION
The regex pattern from PR #3056 would match `<div x-data>`, but it would also match `<div lightbox-data>` and gave a lot of false positives. 

This PR fixes that problem, lowers the confidence slightly for html match and adds additional methods of identification. 