### PR TITLE
Always use string for implies with only one item

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -154,9 +154,7 @@
         5
       ],
       "icon": "Accelerated-Mobile-Pages.svg",
-      "implies": [
-        "WordPress"
-      ],
+      "implies": "WordPress",
       "meta": {
         "generator": "^AMP Plugin v(\\d+\\.\\d+.*)$\\;version:\\1"
       },
@@ -1052,9 +1050,7 @@
         "Server": "Artifactory(?:/([\\d.]+))?\\;version:\\1"
       },
       "icon": "Artifactory.svg",
-      "implies": [
-        "Artifactory"
-      ],
+      "implies": "Artifactory",
       "website": "http://jfrog.com/open-source/#os-arti"
     },
     "ArvanCloud": {
@@ -2087,9 +2083,7 @@
       },
       "script": "clr-angular(?:\\.umd)?(?:\\.min)?\\.js",
       "icon": "clarity.svg",
-      "implies": [
-        "Angular"
-      ],
+      "implies": "Angular",
       "website": "https://clarity.design/"
     },
     "ClickHeat": {
@@ -3180,9 +3174,7 @@
         9
       ],
       "icon": "EasyEngine.png",
-      "implies": [
-        "Docker"
-      ],
+      "implies": "Docker",
       "headers": {
         "x-powered-by": "^EasyEngine (.*)$\\;version:\\1"
       },
@@ -3848,9 +3840,7 @@
         "x-fw-static": "",
         "x-fw-type": ""
       },
-      "implies": [
-        "WordPress"
-      ],
+      "implies": "WordPress",
       "icon": "flywheel.svg",
       "website": "https://getflywheel.com"
     },
@@ -4212,9 +4202,7 @@
         "X-GitHub-Request-Id": ""
       },
       "icon": "GitHub.svg",
-      "implies": [
-        "Ruby on Rails"
-      ],
+      "implies": "Ruby on Rails",
       "url": "^https?://[^/]+\\.github\\.io/",
       "website": "https://pages.github.com/"
     },
@@ -4293,9 +4281,7 @@
         "Server": "GlassFish(?: Server)?(?: Open Source Edition)?(?: ?/?([\\d.]+))?\\;version:\\1"
       },
       "icon": "GlassFish.png",
-      "implies": [
-        "Java"
-      ],
+      "implies": "Java",
       "website": "http://glassfish.java.net"
     },
     "Glyphicons": {
@@ -4860,9 +4846,7 @@
       "script": "bokeh.*\\.js",
       "website": "https://bokeh.org",
       "icon": "bokeh.png",
-      "implies": [
-        "Python"
-      ]
+      "implies": "Python"
     },
     "Highlight.js": {
       "cats": [
@@ -5746,9 +5730,7 @@
       "headers": {
         "Server": "^Kestrel"
       },
-      "implies": [
-        "Microsoft ASP.NET"
-      ],
+      "implies": "Microsoft ASP.NET",
       "icon": "kestrel.svg",
       "website": "https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel"
     },
@@ -7534,9 +7516,7 @@
         "<!-- <meta name=\"NextGEN\" version=\"([\\d.]+)\" /> -->\\;version:\\1"
       ],
       "icon": "NextGEN Gallery.png",
-      "implies": [
-        "WordPress"
-      ],
+      "implies": "WordPress",
       "script": "/nextgen-gallery/js/",
       "website": "https://www.imagely.com/wordpress-gallery-plugin"
     },
@@ -8303,9 +8283,7 @@
       },
       "html": "<[^>]+(?:class|id)=\"phabricator-",
       "icon": "Phabricator.png",
-      "implies": [
-        "PHP"
-      ],
+      "implies": "PHP",
       "script": "/phabricator/[a-f0-9]{8}/rsrc/js/phui/[a-z-]+\\.js$",
       "website": "http://phacility.com"
     },
@@ -8328,9 +8306,7 @@
         "<[^>]+id=\"phenomic(?:root)?\""
       ],
       "icon": "Phenomic.svg",
-      "implies": [
-        "React"
-      ],
+      "implies": "React",
       "script": "/phenomic\\.browser\\.[a-f0-9]+\\.js",
       "website": "https://phenomic.io/"
     },
@@ -9417,9 +9393,7 @@
         9
       ],
       "icon": "SlickStack.png",
-      "implies": [
-        "WordPress"
-      ],
+      "implies": "WordPress",
       "headers": {
         "x-powered-by": "SlickStack"
       },
@@ -9698,9 +9672,7 @@
       "headers": {
         "x-powered-by": "^Seravo"
       },
-      "implies": [
-        "WordPress"
-      ],
+      "implies": "WordPress",
       "icon": "seravo.svg",
       "website": "https://seravo.com"
     },
@@ -10863,9 +10835,7 @@
       "cookies": {
         "TNEW": ""
       },
-      "implies": [
-        "Tessitura"
-      ],
+      "implies": "Tessitura",
       "icon": "tessitura.svg",
       "website": "https://www.tessituranetwork.com"
     },
@@ -12097,9 +12067,7 @@
         "X-Wix-Server-Artifact-Id": ""
       },
       "icon": "Wix.png",
-      "implies": [
-        "React"
-      ],
+      "implies": "React",
       "js": {
         "wixBiSession": ""
       },
@@ -12201,9 +12169,7 @@
       "headers": {
         "x-powered-by": "^WordPress\\.com VIP"
       },
-      "implies": [
-        "WordPress"
-      ],
+      "implies": "WordPress",
       "icon": "wpvip.svg",
       "website": "https://wpvip.com"
     },
@@ -12372,9 +12338,7 @@
         "X-Powered-By": "XeoraCube"
       },
       "html": "<input type=\"hidden\" name=\"_sys_bind_\\d+\" id=\"_sys_bind_\\d+\" />",
-      "implies": [
-        "Microsoft ASP.NET"
-      ],
+      "implies": "Microsoft ASP.NET",
       "icon": "xeora.png",
       "script": "/_bi_sps_v.+\\.js",
       "website": "http://www.xeora.org"
@@ -12525,9 +12489,7 @@
         "Server": "Yaws(?: ([\\d.]+))?\\;version:\\1"
       },
       "icon": "Yaws.png",
-      "implies": [
-        "Erlang"
-      ],
+      "implies": "Erlang",
       "website": "http://yaws.hyber.org"
     },
     "Yieldlab": {
@@ -12551,9 +12513,7 @@
         "<!\\[CDATA\\[YII-BLOCK-(?:HEAD|BODY-BEGIN|BODY-END)\\]"
       ],
       "icon": "Yii.png",
-      "implies": [
-        "PHP"
-      ],
+      "implies": "PHP",
       "script": [
         "/assets/[a-zA-Z0-9]{8}\\/yii\\.js$",
         "/yii\\.(?:validation|activeForm)\\.js"
@@ -13036,9 +12996,7 @@
         1
       ],
       "icon": "govCMS.svg",
-      "implies": [
-        "Drupal"
-      ],
+      "implies": "Drupal",
       "meta": {
         "generator": "Drupal ([\\d]+) \\(http:\\/\\/drupal\\.org\\) \\+ govCMS\\;version:\\1"
       },
@@ -13236,9 +13194,7 @@
       "headers": {
         "x-kinsta-cache": ""
       },
-      "implies": [
-        "WordPress"
-      ],
+      "implies": "WordPress",
       "icon": "kinsta.svg",
       "website": "https://kinsta.com"
     },
@@ -13709,9 +13665,7 @@
       "icon": "Siteglide.svg",
       "script": "siteglide\\.js",
       "website": "https://www.siteglide.com",
-      "implies": [
-        "PlatformOS"
-      ]
+      "implies": "PlatformOS"
     },
     "sNews": {
       "cats": [
@@ -13767,9 +13721,7 @@
         "<[^>]+sc-component-id: sc-"
       ],
       "icon": "styled-components.png",
-      "implies": [
-        "React"
-      ],
+      "implies": "React",
       "js": {
         "styled": ""
       },


### PR DESCRIPTION
Changes all `implies` arrays that only had one item to use string syntax instead. 

If you'd prefer to always use array, just let me know and I'll update the PR.