### PR TITLE
Add RebelMouse specific header detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -14424,6 +14424,10 @@
       "cats": [
         1
       ],
+      "headers": {
+        "x-rebelmouse-cache-control": "",
+        "x-rebelmouse-surrogate-control": ""
+      },
       "icon": "RebelMouse.svg",
       "html": "<!-- Powered by RebelMouse\\.",
       "website": "https://www.rebelmouse.com/"


### PR DESCRIPTION
RebelMouse, a WordPress-like CMS, uses specific caching headers for their service which can be detected.