### PR TITLE
Fix overly broad Angular detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -808,7 +808,7 @@
       "script": [
         "angular[.-]([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
         "/([\\d.]+(?:-?rc[.\\d]*)*)/angular(?:\\.min)?\\.js\\;version:\\1",
-        "angular.*\\.js"
+        "\\bangular.{0,32}\\.js"
       ],
       "website": "https://angularjs.org"
     },


### PR DESCRIPTION
Was triggered on "rectangular[several KiB of minified script].js"
Now requires a word boundary before "angular" and allows max. 32
characters between that and ".js"