### PR TITLE
npm - add timeout to javascript evaluation

### DIFF
--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -375,7 +375,12 @@ class Site {
     ).jsonValue()
 
     // JavaScript
-    const win = await page.evaluate(getJs)
+    const win = await Promise.race([
+      page.evaluate(getJs),
+      new Promise((resolve, reject) =>
+        setTimeout(() => reject(new Error('Timeout')), this.options.maxWait)
+      )
+    ])
 
     const js = Wappalyzer.technologies
       .filter(({ js }) => Object.keys(js).length)


### PR DESCRIPTION
Just stumbled upon a similar issue to #3181: [this site](http://www.caixa.gov.br/) exposes window.Module, which for some reason contains `HEAP` properties with millions of items – again causing the `dereference` function to execute until it runs out of memory...

I added a timeout for the javascript execution to stop if the browser doesn't return within `maxWait` seconds.