### PR TITLE
Fix the bug of not showing popup when the url contains hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "@prantlf/jsonlint": "^10.2.0",
     "adm-zip": "^0.4.14",
-    "convert-svg-to-png": "^0.5.0"
+    "convert-svg-to-png": "^0.5.0",
+    "languagedetect": "^2.0.0"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config": "^1.0.1",

--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -137,7 +137,7 @@ class Driver {
   }
 
   open(url) {
-    return new Site(url, this)
+    return new Site(url.split('#')[0], this)
   }
 
   log(message, source = 'driver') {

--- a/src/drivers/webextension/js/content.js
+++ b/src/drivers/webextension/js/content.js
@@ -111,7 +111,7 @@ const Content = {
         chrome.runtime.sendMessage({
           source: 'content.js',
           func: 'analyzeJs',
-          args: [location.href, data.wappalyzer.js]
+          args: [location.href.split('#')[0], data.wappalyzer.js]
         })
 
         script.remove()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,6 +1242,11 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+languagedetect@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/languagedetect/-/languagedetect-2.0.0.tgz#4b8fa2b7593b2a3a02fb1100891041c53238936c"
+  integrity sha512-AZb/liiQ+6ZoTj4f1J0aE6OkzhCo8fyH+tuSaPfSo8YHCWLFJrdSixhtO2TYdIkjcDQNaR4RmGaV2A5FJklDMQ==
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"


### PR DESCRIPTION
@AliasIO
Fix #3204
- 04aa67964f9058305471d5fc8a3fac637f6ad6b5 **Yarn:** `yarn add languagedetect` (Fix `Error: Cannot find module 'languagedetect'`)
- 9a53d48f4155ada54d7838ad7800277bee85a93d **WebExtension:** Remove hash from url (Fix the bug of not showing popup when the url contains hash, such as [`https://github.com/AliasIO/wappalyzer#readme`](https://github.com/AliasIO/wappalyzer#readme))
- b132d3b3cf203a2a8d5c369b104b97b0b5685d35 **Node:** Remove hash from url (Fix `NO_RESPONSE` of `node src/drivers/npm/cli.js https://github.com/AliasIO/wappalyzer\#readme`)