### PR TITLE
Improve MediaWiki Detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -7210,7 +7210,9 @@
       "icon": "MediaWiki.png",
       "implies": "PHP",
       "js": {
-        "mw.util.toggleToc": ""
+        "mw": "",
+        "wgTitle": "",
+        "wgVersion": "^(.+)$\\;version:\\1"
       },
       "meta": {
         "generator": "^MediaWiki ?(.+)$\\;version:\\1"


### PR DESCRIPTION
Fix the detection of older versions of MediaWiki (`wg`), such as <https://wiki.mbalib.com>.
```json
"js": {
  "mw": "",
  "wgTitle": "",
  "wgVersion": "^(.+)$\\;version:\\1"
}
```