### PR TITLE
Add another way of detecting hubspot

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -5443,6 +5443,9 @@
         "_hsq": "",
         "hubspot": ""
       },
+      "meta": {
+        "generator": "HubSpot"
+      },
       "website": "https://www.hubspot.com"
     },
     "Hugo": {


### PR DESCRIPTION
Hubspot could only be detected by evaluating js context, which isn't always possble. Fortunately hubspot also provides a generator meta tag