### PR TITLE
Fix blogger.com detection

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1650,7 +1650,7 @@
       "meta": {
         "generator": "^Blogger$"
       },
-      "url": "^https?://[^/]+\\.blogspot\\.com",
+      "url": "^https?://[^/]+\\.(blogspot|blogger)\\.com",
       "website": "http://www.blogger.com"
     },
     "Bloomreach": {


### PR DESCRIPTION
I am using blogger on a URL like this:

https://www.blogger.com/blog/post/edit/123456789/123456789

This PR adds `blogger.com` to the URL regex for blogger