### PR TITLE
Add wordpress version detection from scripts

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -13400,7 +13400,10 @@
         "generator": "^WordPress ?([\\d.]+)?\\;version:\\1",
         "shareaholic:wp_version": ""
       },
-      "script": "/wp-(?:content|includes)/",
+      "script": [
+        "/wp-(?:content|includes)/",
+        "wp-embed\\.min\\.js\\?ver=([\\d.]+)\\;version:\\1"
+      ],
       "website": "https://wordpress.org"
     },
     "WordPress Super Cache": {


### PR DESCRIPTION
Wordpress will often have its version exposed through a script tag such as the following:
 
```
<script type='text/javascript' src='https://.../wp-includes/js/wp-embed.min.js?ver=5.4.2'></script>
```
