### PR TITLE
Tomcat version bug

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -1078,7 +1078,7 @@
       ],
       "cpe": "cpe:/a:apache:tomcat",
       "headers": {
-        "Server": "^Apache-Coyote(?:/([\\d.]+))?\\;version:\\1\\;confidence:50",
+        "Server": "^Apache-Coyote(?:/([\\d.]+))?",
         "X-Powered-By": "\\bTomcat\\b(?:-([\\d.]+))?\\;version:\\1"
       },
       "icon": "Apache Tomcat.svg",

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -1078,7 +1078,7 @@
       ],
       "cpe": "cpe:/a:apache:tomcat",
       "headers": {
-        "Server": "^Apache-Coyote(?:/([\\d.]+))?\\;version:\\1",
+        "Server": "^Apache-Coyote(?:/([\\d.]+))?\\;version:\\1\\;confidence:50",
         "X-Powered-By": "\\bTomcat\\b(?:-([\\d.]+))?\\;version:\\1"
       },
       "icon": "Apache Tomcat.svg",


### PR DESCRIPTION
Removing version detect for the `Apache-Coyote` Header because its producing false version numbers.
- fixes #3305
