### PR TITLE
Add support for other GOV.UK products and refine detection of Frontend

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -4808,17 +4808,69 @@
       "icon": "G-WAN.png",
       "website": "http://gwan.com"
     },
-    "GOV.UK Frontend": {
+    "GOV.UK Elements": {
       "cats": [
-        66,
-        19
+        66
       ],
       "html": [
-        "<body[^>]+govuk-template__body",
-        "<a[^>]+govuk-link"
+        "<link[^>]+elements-page[^>\"]+css\\;confidence:25",
+        "<div[^>]+phase-banner-alpha\\;confidence:25",
+        "<div[^>]+phase-banner-beta\\;confidence:25",
+        "<div[^>]+govuk-box-highlight\\;confidence:25"
+      ],
+      "implies": "GOV.UK Toolkit",
+      "icon": "govuk.png",
+      "website": "https://github.com/alphagov/govuk_elements/"
+    },
+    "GOV.UK Frontend": {
+      "cats": [
+        66
+      ],
+      "html": [
+        "<link[^>]* href=[^>]*?govuk-frontend(?:[^>]*?([0-9a-fA-F]{7,40}|[\\d]+(?:.[\\d]+(?:.[\\d]+)?)?)|)[^>]*?(?:\\.min)?\\.css\\;version:\\1?a:",
+        "<body[^>]+govuk-template__body\\;confidence:80",
+        "<a[^>]+govuk-link\\;confidence:10"
+      ],
+      "js": {
+        "window.GOVUKFrontend": ""
+      },
+      "scripts": [
+        "govuk-frontend(?:[^>]*?([0-9a-fA-F]{7,40}|[\\d]+(?:.[\\d]+(?:.[\\d]+)?)?)|)[^>]*?(?:\\.min)?\\.js\\;version:\\1?a:"
       ],
       "icon": "govuk.png",
       "website": "https://design-system.service.gov.uk/"
+    },
+    "GOV.UK Template": {
+      "cats": [
+        66
+      ],
+      "html": [
+        "<link[^>]+govuk-template[^>\"]+css",
+        "<link[^>]+govuk-template-print[^>\"]+css",
+        "<link[^>]+govuk-template-ie6[^>\"]+css",
+        "<link[^>]+govuk-template-ie7[^>\"]+css",
+        "<link[^>]+govuk-template-ie8[^>\"]+css"
+      ],
+      "js": {
+        "window.GOVUK": ""
+      },
+      "scripts": [
+        "govuk-template\\.js"
+      ],
+      "icon": "govuk.png",
+      "website": "https://github.com/alphagov/govuk_template/"
+    },
+    "GOV.UK Toolkit": {
+      "cats": [
+        66
+      ],
+      "js": {
+        "window.GOVUK.primaryLinks": "",
+        "window.GOVUK.details": "",
+        "window.GOVUK.modules": ""
+      },
+      "icon": "govuk.png",
+      "website": "https://github.com/alphagov/govuk_frontend_toolkit"
     },
     "GSAP": {
       "cats": [

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -4832,7 +4832,7 @@
         "<a[^>]+govuk-link\\;confidence:10"
       ],
       "js": {
-        "window.GOVUKFrontend": ""
+        "GOVUKFrontend": ""
       },
       "scripts": [
         "govuk-frontend(?:[^>]*?([0-9a-fA-F]{7,40}|[\\d]+(?:.[\\d]+(?:.[\\d]+)?)?)|)[^>]*?(?:\\.min)?\\.js\\;version:\\1?a:"
@@ -4852,7 +4852,7 @@
         "<link[^>]+govuk-template-ie8[^>\"]+css"
       ],
       "js": {
-        "window.GOVUK": ""
+        "GOVUK": ""
       },
       "scripts": [
         "govuk-template\\.js"
@@ -4865,9 +4865,9 @@
         66
       ],
       "js": {
-        "window.GOVUK.primaryLinks": "",
-        "window.GOVUK.details": "",
-        "window.GOVUK.modules": ""
+        "GOVUK.primaryLinks": "",
+        "GOVUK.details": "",
+        "GOVUK.modules": ""
       },
       "icon": "govuk.png",
       "website": "https://github.com/alphagov/govuk_frontend_toolkit"
@@ -7452,7 +7452,7 @@
       },
       "icon": "Loja Integrada.png",
       "js": {
-        "window.LOJA_ID": ""
+        "LOJA_ID": ""
       },
       "website": "https://lojaintegrada.com.br/"
     },
@@ -7773,7 +7773,7 @@
       "description": "Matomo Tag Manager manages tracking and marketing tags.",
       "icon": "Matomo.png",
       "js": {
-        "window.MatomoTagManager": ""
+        "MatomoTagManager": ""
       },
       "website": "https://developer.matomo.org/guides/tagmanager/introduction"
     },


### PR DESCRIPTION
This PR does the following:

- Refines the detection of GOV.UK Frontend as we were getting lots of false positives off copy / pasted cookie banners
- Adds the detection of GOV.UK Frontend's version number if a service team is using the `dist` version of the CSS or JS
- Adds detection of three other GOV.UK Products: GOV.UK Template, GOV.UK Elements, GOV.UK Toolkit
- All products are now use the 'UI Frameworks' category, rather than doubling up in 'Miscellaneous'
