### PR TITLE
Improving Google Tag Manager Detection

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -5494,6 +5494,9 @@
         "google_tag_manager": "",
         "googletag": ""
       },
+      "scripts": [
+        "googletagmanager\\.com/gtm\\.js"
+      ],
       "website": "http://www.google.com/tagmanager"
     },
     "Google Wallet": {


### PR DESCRIPTION
Detecting googletagmanger with url `googletagmanager.com/gtm.js`

- fixes #3355 