### PR TITLE
Fix typo in GOV.UK Frontend version number

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -5065,7 +5065,7 @@
         66
       ],
       "html": [
-        "<link[^>]* href=[^>]*?govuk-frontend(?:[^>]*?([0-9a-fA-F]{7,40}|[\\d]+(?:.[\\d]+(?:.[\\d]+)?)?)|)[^>]*?(?:\\.min)?\\.css\\;version:\\1?a:",
+        "<link[^>]* href=[^>]*?govuk-frontend(?:[^>]*?([0-9a-fA-F]{7,40}|[\\d]+(?:.[\\d]+(?:.[\\d]+)?)?)|)[^>]*?(?:\\.min)?\\.css\\;version:\\1",
         "<body[^>]+govuk-template__body\\;confidence:80",
         "<a[^>]+govuk-link\\;confidence:10"
       ],
@@ -5074,7 +5074,7 @@
         "GOVUKFrontend": ""
       },
       "scripts": [
-        "govuk-frontend(?:[^>]*?([0-9a-fA-F]{7,40}|[\\d]+(?:.[\\d]+(?:.[\\d]+)?)?)|)[^>]*?(?:\\.min)?\\.js\\;version:\\1?a:"
+        "govuk-frontend(?:[^>]*?([0-9a-fA-F]{7,40}|[\\d]+(?:.[\\d]+(?:.[\\d]+)?)?)|)[^>]*?(?:\\.min)?\\.js\\;version:\\1"
       ],
       "website": "https://design-system.service.gov.uk/"
     },


### PR DESCRIPTION
Version number detected but only returns `a` because of typo copied from example in docs.

Apologies for this minor update, I'm frustrated I didn't spot it sooner.