### PR TITLE
Zone.js implies Angular

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -15317,6 +15317,7 @@
       "cats": [
         12
       ],
+      "implies": "Angular",
       "js": {
         "Zone.root": ""
       },


### PR DESCRIPTION
Google Fonts uses Angular, but Angular is not detected. However, Zone.js is, which is a part of Angular.