### PR TITLE
Remove trailing comma (invalid JSON)

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -7189,7 +7189,7 @@
     "Klarna Checkout": {
       "cats": [
         41,
-        6,
+        6
       ],
       "description": "Klarna Checkout is a complete payment solution where Klarna handles a store's entire checkout.",
       "icon": "Klarna.svg",


### PR DESCRIPTION
Hi guys, 

while trying to load your latest version with python's json module, I got the following error: "JSONDecodeError: Expecting value: line 7193 column 7".

If you remove only this one trailing comma, it works like a charm. 
Hope this change will be okay for you. 

Thanks in advance & greetings