### PR TITLE
#3445: Close timers after resolving/erroring the `dns.*` promises

### DIFF
--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -637,17 +637,16 @@ class Site {
       // DNS
       if (!this.dns.length) {
         const records = {}
-
         const resolve = async (func, hostname) => {
-          try {
-            return await this.promiseTimeout(func(hostname))
-          } catch (error) {
-            if (error.code !== 'ENODATA') {
-              this.error(error)
-            }
+          return this.promiseTimeout(
+            func(hostname).catch((error) => {
+              if (error.code !== 'ENODATA') {
+                this.error(error)
+              }
 
-            return []
-          }
+              return []
+            })
+          )
         }
 
         const domain = url.hostname.replace(/^www\./, '')


### PR DESCRIPTION
https://github.com/AliasIO/wappalyzer/issues/3445