### PR TITLE
Improve Confluence vs Jira detection

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -1640,7 +1640,7 @@
       "headers": {
         "X-Confluence-Request-Time": ""
       },
-      "html": "Powered by <a href=[^>]+atlassian\\.com/software/confluence(?:[^>]+>Atlassian Confluence</a> ([\\d.]+))?\\;version:\\1",
+      "html": "Atlassian Confluence ([\\d.]+)\\;version:\\1",
       "icon": "Atlassian Confluence.svg",
       "implies": "Java",
       "meta": {
@@ -1665,14 +1665,13 @@
         13
       ],
       "cpe": "cpe:/a:atlassian:jira",
-      "html": "Powered by\\s+<a href=[^>]+atlassian\\.com/(?:software/jira|jira-bug-tracking/)[^>]+>Atlassian\\s+JIRA(?:[^v]*v(?:ersion: )?(\\d+\\.\\d+(?:\\.\\d+)?))?\\;version:\\1",
+      "html": "data-version=\"([\\d.]+)\\;version:\\1",
       "icon": "Atlassian Jira.svg",
       "implies": "Java",
       "js": {
         "jira": ""
       },
       "meta": {
-        "ajs-version-number": "^(.+)$\\;version:\\1",
         "application-name": "JIRA"
       },
       "website": "http://www.atlassian.com/software/jira/overview/"

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -1640,7 +1640,7 @@
       "headers": {
         "X-Confluence-Request-Time": ""
       },
-      "html": "Atlassian Confluence ([\\d.]+)\\;version:\\1",
+      "html": "<li class=\"print-only\">.+ Atlassian Confluence ([\\d.]+)</li>\\;version:\\1",
       "icon": "Atlassian Confluence.svg",
       "implies": "Java",
       "meta": {
@@ -1665,14 +1665,15 @@
         13
       ],
       "cpe": "cpe:/a:atlassian:jira",
-      "html": "data-version=\"([\\d.]+)\\;version:\\1",
+      "html": "<body.+data-version=\"([\d.]+)\">\\;version:\\1",
       "icon": "Atlassian Jira.svg",
       "implies": "Java",
       "js": {
         "jira": ""
       },
       "meta": {
-        "application-name": "JIRA"
+        "application-name": "JIRA",
+        "data-version": ([\\d.]+)\\;version:\\1
       },
       "website": "http://www.atlassian.com/software/jira/overview/"
     },

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -1640,7 +1640,11 @@
       "headers": {
         "X-Confluence-Request-Time": ""
       },
-      "html": "<li class=\"print-only\">.+ Atlassian Confluence ([\\d.]+)</li>\\;version:\\1",
+      "dom": {
+        "li.print-only": {
+          "text": "Atlassian Confluence ([\\d.]+)\\;version:\\1"
+        }
+      },
       "icon": "Atlassian Confluence.svg",
       "implies": "Java",
       "meta": {

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -1665,15 +1665,19 @@
         13
       ],
       "cpe": "cpe:/a:atlassian:jira",
-      "html": "<body.+data-version=\"([\d.]+)\">\\;version:\\1",
       "icon": "Atlassian Jira.svg",
       "implies": "Java",
       "js": {
-        "jira": ""
+        "jira.id": ""
+      },
+      "dom": {
+        "#jira": {
+          "text": ""
+        }
       },
       "meta": {
         "application-name": "JIRA",
-        "data-version": ([\\d.]+)\\;version:\\1
+        "data-version": ([\\d.]+)\\;version:\\1\\;confidence:0
       },
       "website": "http://www.atlassian.com/software/jira/overview/"
     },


### PR DESCRIPTION
Hey guys,

using wappalyzer recently I discovered, that a lot of times websites get marked as Atlassian Confluence AND Jira. However, only the Jira technology is capable of finding a version and the Confluence was not.
This is happening, because both applications have the "ajs-version-number" (which is stated within the Atlassian Jira app rule). As well, the provided html-regex ("Powered by...") is not working - at least on pages I encountered. Tested it as well manually.

So my suggestion for lower false-positives would be:

- Remove "ajs-version-number" from JIRA - because both apps have it.
- Jira pages have one attribute within a meta-tag and the body-tag: "data-version", which we can take advantage of -> therefore changed the html-regex
- Confluence pages have in addition to "Powered by ..." the "Printed by Atlassian Confluence [_version_]" within the footer section. However, depending on the language the only useable part is "Atlassian Confluence [_version_]" ("Printed by" gets translated). I guess the "Powered by..." regex could be revised as well, but in my opinion it does make the regex simpler for the same result - this is why I suggest using it.

It is a proposal and I wanted feedback from the community about this. 
If you have any input, let me know and I will work on it. 

Greetings