### PR TITLE
fix(Rakuten): duplicate Rakuten entery

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -11779,23 +11779,6 @@
       },
       "website": "https://www.webgains.com/"
     },
-    "Rakuten": {
-      "cats": [
-        71,
-        61
-      ],
-      "description": "Rakuten (formerly Ebates) allows you to earn cash-back rewards.",
-      "icon": "Rakuten.svg",
-      "script": "tag\\.rmp\\.rakuten\\.com",
-      "js": {
-        "rakutenSource": "",
-        "rakutenRanMID": ""
-      },
-      "cookies": {
-        "rakuten-source": ""
-      },
-      "website": "https://www.rakuten.com/"
-    },
     "AWIN": {
       "cats": [
         71,


### PR DESCRIPTION
Fix following error:

```
$ yarn run validate
yarn run v1.22.10
$ yarn run lint && jsonlint -qV ./schema.json ./src/technologies.json && node ./bin/validate.js
$ eslint --fix src/**/*.js
File: src/technologies.json
Parse error on line 11266, column 16:
...  },    "Rakuten": {      "cats": [  ...
----------------------^
/technologies/Rakuten should NOT have additional properties; see #/properties/technologies/additionalProperties/additionalProperties
```

Rakuten had a duplicate entry﻿
