### PR TITLE
feat(AOS): add AOS (#3350)

### DIFF
--- a/src/drivers/webextension/images/icons/AOS.svg
+++ b/src/drivers/webextension/images/icons/AOS.svg
@@ -1,0 +1,1 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46.09 51.64"><path d="M290.58,175.43h-7.91l-19.44,51.65h7.17L276,211.61l20,0,5.66,15.44h7.66Zm-12.39,30.48,8.33-22.81,7.84,22.81Z" transform="translate(-263.23 -175.43)" style="fill:#323962"/></svg>

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -412,6 +412,20 @@
       "icon": "AOLserver.png",
       "website": "http://aolserver.com"
     },
+    "AOS": {
+      "cats": [
+        59
+      ],
+      "description": "JavaScript library to animate elements on your page as you scroll.",
+      "js": {
+        "AOS.init": "\\;confidence:25",
+        "AOS.refresh": "\\;confidence:50",
+        "AOS.refreshHard": "\\;confidence:50"
+      },
+      "scripts": "unpkg\\.com/aos@(next)/dist/aos\\.js\\;version:\\1",
+      "icon": "AOS.svg",
+      "website": "http://michalsnik.github.io/aos/"
+    },
     "AT Internet Analyzer": {
       "cats": [
         10


### PR DESCRIPTION
Add AOS detection as requested by honjes in #3350 

AOS has 14k stars, https://github.com/michalsnik/aos, so should meet notability requirements 

Works on all of the sites here https://trends.builtwith.com/websitelist/AOS 

Added the confidence for "js" as AOS is kinda short and may have conflicts with minified code, but should be rather safe if all 3 of the methods are there﻿

<img width="680" alt="Screenshot 2020-11-08 at 03 40 09" src="https://user-images.githubusercontent.com/57638117/98456311-1bb98c80-2174-11eb-943b-639d08e46c55.png">