### PR TITLE
Fix runtime.lastError

### DIFF
--- a/src/drivers/webextension/js/driver.js
+++ b/src/drivers/webextension/js/driver.js
@@ -54,7 +54,7 @@ const Driver = {
       ),
       tabs: {},
       robots: await getOption('robots', {}),
-      ads: {},
+      ads: [],
     }
 
     chrome.browserAction.setBadgeBackgroundColor({ color: '#6B39BD' }, () => {})


### PR DESCRIPTION
Fix to #3529 

In this commit: https://github.com/AliasIO/wappalyzer/commit/3097ddcde8479980f0929bf61b9bc07749433a84#diff-3a09560d3fab721a41189cfa740746e5f2ee1d7562d30fd862f17d4df9f517ec `ads: await getOption('ads', []),` got replaced with `{}`

Since line 463 had `Driver.cache.ads.push(ad)`﻿it is not going to be able to push to an object

Here is the error that caused it to throw an error when visiting websites:
<img width="1572" alt="Screenshot 2020-11-15 at 16 13 34" src="https://user-images.githubusercontent.com/57638117/99190270-86169200-275d-11eb-945b-0f605a3dd83a.png">
