### PR TITLE
Add WebAssembly

### DIFF
--- a/src/drivers/webextension/images/icons/WebAssembly.svg
+++ b/src/drivers/webextension/images/icons/WebAssembly.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 107.62 107.62">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #654ff0;
+      }
+    </style>
+  </defs>
+  <title>web-assembly-icon</title>
+  <g id="Layer_2" data-name="Layer 2">
+    <g id="Notch_-_Purple" data-name="Notch - Purple">
+      <g id="icon">
+        <path class="cls-1" d="M66.12,0c0,.19,0,.38,0,.58a12.34,12.34,0,1,1-24.68,0c0-.2,0-.39,0-.58H0V107.62H107.62V0ZM51.38,96.1,46.14,70.17H46L40.39,96.1H33.18L25,58h7.13L37,83.93h.09L42.94,58h6.67L54.9,84.25H55L60.55,58h7L58.46,96.1Zm39.26,0-2.43-8.48H75.4L73.53,96.1H66.36L75.59,58H86.83L98,96.1Z"/>
+        <polygon class="cls-1" points="79.87 67.39 76.76 81.37 86.44 81.37 82.87 67.39 79.87 67.39"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -18270,6 +18270,18 @@
       },
       "website": "http://vibecommerce.com.br"
     },
+    "WebAssembly": {
+      "cats": [
+        27
+      ],
+      "description": "WebAssembly (abbreviated Wasm) is a binary instruction format for a stack-based virtual machine. Wasm is designed as a portable compilation target for programming languages, enabling deployment on the web for client and server applications.",
+      "icon": "WebAssembly.svg",
+      "oss": true,
+      "headers": {
+        "Content-Type": "application/wasm"
+      },
+      "website": "https://webassembly.org/"
+    },
     "webEdition": {
       "cats": [
         1


### PR DESCRIPTION
I wondered whether watching a Content-Type or a extension, but I choose the former. Because after I saw codes roughly, I noticed implement of "scripts" make browser evaluate a script. I don't know can browsers evaluate wasm byte-codes directly, but I tried it and it worked. Though it seemed strange action, so I decide to watch headers.