### PR TITLE
fix: remove unused image

### DIFF
--- a/src/drivers/webextension/images/icons/default-safari.svg
+++ b/src/drivers/webextension/images/icons/default-safari.svg
@@ -1,4 +1,0 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M15.9999 30.1089L1.21227 20.0056L15.9999 9.90245L30.7875 20.0055L15.9999 30.1089Z" stroke="#4BA0F8" stroke-width="2"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M15.9999 1L0.000841659 11.9308L0 12.6971L15.9999 23.6287L31.9989 12.6976L31.9998 11.9313L15.9999 1Z" fill="#4BA0F8"/>
-</svg>


### PR DESCRIPTION
it broke check.
the image default-safari.svg was added at https://github.com/AliasIO/wappalyzer/commit/d1f425b4b8806c668ae70aa76e9fed027762b361
and then the check was broken
Related: https://github.com/AliasIO/wappalyzer/issues/3567