### PR TITLE
Add Docusaurus to the SSG category

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -4312,7 +4312,8 @@
     },
     "Docusaurus": {
       "cats": [
-        4
+        4,
+        57
       ],
       "description": "Docusaurus is a tool for teams to publish documentation websites.",
       "icon": "docusaurus.svg",


### PR DESCRIPTION
Actually Docusaurus is static generator website. Of course, it is used a lot as a tool for creating documentation. But with [v2](https://v2.docusaurus.io/), which many people are already using, Docusaurus has become a full-fledged SSG.

сс @AliasIO 