### PR TITLE
Add SMSBump/Marketing automation

### DIFF
--- a/src/drivers/webextension/images/icons/SMSBump.svg
+++ b/src/drivers/webextension/images/icons/SMSBump.svg
@@ -1,0 +1,10 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M21.2878 3.87878L9.16367 20.7457L2.00439 16.6119L0.969727 18.4019L10.6764 26.3922L23.0788 4.91345L21.2878 3.87878ZM30.5154 4.43345L18.3903 21.2984L16.6003 20.2657L15.0507 22.9498L19.9031 26.945L32.3055 5.46618L30.5154 4.43345Z" fill="#38D554"/>
+</g>
+<defs>
+<clipPath id="clip0">
+<rect width="32" height="32" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -14175,6 +14175,27 @@
       },
       "website": "https://www.smartstore.com"
     },
+    "SMSBump": {
+      "cats": [
+        32
+      ],
+      "description": "SMSBump is a text marketing automation app available for Shopify, BigCommerce and OpenCart.",
+      "icon": "SMSBump.svg",
+      "dom": {
+        "div[id*='smsbump-form']": {
+          "attributes": {
+            "id": ""
+          }
+        }
+      },
+      "js": {
+        "SMSBumpForm": ""
+      },
+      "scripts": "smsbump\\.com",
+      "saas": true,
+      "pricing": ["low", "freemium", "recurring"],
+      "website": "https://smsbump.com"
+    },
     "Snap": {
       "cats": [
         18,

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -14182,12 +14182,12 @@
       "description": "SMSBump is a text marketing automation app available for Shopify, BigCommerce and OpenCart.",
       "icon": "SMSBump.svg",
       "dom": {
-        "div[id*='smsbump-form']": {
+        "div#smsbump-form": {
           "attributes": {
             "id": ""
           }
         },
-        "link[class*='smsbump']": {
+        "link.smsbump": {
           "attributes": {
             "class": ""
           }

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -14186,6 +14186,11 @@
           "attributes": {
             "id": ""
           }
+        },
+        "link[class*='smsbump']": {
+          "attributes": {
+            "class": ""
+          }
         }
       },
       "js": {


### PR DESCRIPTION
Website:
https://smsbump.com/

Example websites:
https://www.dickpondathletics.com/ (BigCommerce )

Not covered examples (Shopify):
**https://d3dsecurity.com/, https://www.furgrip.co.uk/** 
```
"link[class*='smsbump']": {
          "attributes": {
            "class": ""
          }
        }
```

**https://lucyave.com/**
```
"div[id*='smsbump-form']": {
          "attributes": {
            "id": ""
          }
        },
```
