### PR TITLE
Update generator regex for Docusaurus

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -4419,7 +4419,7 @@
         "search.indexName": ""
       },
       "meta": {
-        "generator": "^Docusaurus$"
+        "generator": "^Docusaurus(?: v(.+))?$\\;version:\\1"
       },
       "website": "https://docusaurus.io/"
     },


### PR DESCRIPTION
The meta generator value of the second (new) version of Docusaurus looks like this: `Docusaurus v2.0.0-alpha.x`.
So currently, in fact, Wapplyzer does not recognize sites created with Docusaurus v2. But without breaking the recognization of sites on Docusaurus v1 (just `Docusaurus` without specifying version).
This PR is trying to fix it.

сс @AliasIO 