### PR TITLE
Update Elementor

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -5276,7 +5276,7 @@
       "cats": [
         51
       ],
-      "description": "Elementor is the leading website builder platform for professionals on WordPress.",
+      "description": "Elementor is a website builder platform for professionals on WordPress.",
       "html": [
         "<div class=(?:\"|')[^\"']*elementor",
         "<section class=(?:\"|')[^\"']*elementor",

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -5276,7 +5276,7 @@
       "cats": [
         51
       ],
-      "description": "WordPress is a free and open-source content management system used to create a website or blog.",
+      "description": "Elementor is the leading website builder platform for professionals on WordPress.",
       "html": [
         "<div class=(?:\"|')[^\"']*elementor",
         "<section class=(?:\"|')[^\"']*elementor",
@@ -5284,7 +5284,6 @@
         "<link [^>]*href=(?:\"|')[^\"']*uploads/elementor/css"
       ],
       "icon": "Elementor.png",
-      "implies": "WordPress",
       "js": {
         "elementorFrontend.getElements": ""
       },


### PR DESCRIPTION
Remove the implied WordPress rule as Elementor could be used without WordPress, and more likely than not, WordPress will be detected on it’s own signatures.

fixes #3690