### PR TITLE
Fix Oracle Commerce

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -11806,7 +11806,6 @@
       "headers": {
         "X-ATG-Version": "(?:ATGPlatform/([\\d.]+))?\\;version:\\1"
       },
-      "html": "<[^>]+_dyncharset",
       "icon": "Oracle.png",
       "website": "http://www.oracle.com/applications/customer-experience/commerce/products/commerce-platform/index.html"
     },


### PR DESCRIPTION
Remove false positive from Oracle Commerce. The dyncharset is too vague and promotes false positives. This should be detected as a URL parameter rather than a string on the page, so instead we'll remove it for now.

fixes #3667