### PR TITLE
Optimizing SVG conversion build time

### DIFF
--- a/bin/convert.js
+++ b/bin/convert.js
@@ -1,0 +1,128 @@
+const fs = require('fs')
+const path = require('path')
+const { convertFile } = require('convert-svg-to-png')
+
+const appPaths = () => {
+  const fileDir = path.dirname(require.main.filename).split('/')
+  // Remove current bin directory
+  fileDir.pop()
+  const appDir = fileDir.join('/')
+
+  return {
+    basePath: fileDir,
+    appPath: appDir,
+    iconPath: appDir + '/src/drivers/webextension/images/icons',
+    convertPath: appDir + '/src/drivers/webextension/images/icons/converted',
+  }
+}
+
+// Main script
+fs.readdirSync(appPaths().iconPath).forEach((fileName) => {
+  const image = {
+    id: fileName,
+    path: `${appPaths().iconPath}/${fileName}`,
+    convertPath: `${appPaths().convertPath}/${fileName}`,
+    /**
+     * Copy files from source to destination.
+     * @param source
+     * @param destination
+     */
+    copyFiles(source, destination) {
+      // File destination will be created or overwritten by default.
+      fs.copyFileSync(source, destination)
+      console.log(`Copied icon: ${this.id}`)
+    },
+    /**
+     * Get extension of image file.
+     * @returns {string}
+     */
+    getFileExtension() {
+      return path.extname(this.path)
+    },
+    /**
+     * Get base name of image file.
+     * @returns {string}
+     */
+    getFileName() {
+      return path.basename(this.path, this.getFileExtension())
+    },
+    getConvertFileName() {
+      const name = this.getFileName()
+      return `${appPaths().convertPath}/${name}.png`
+    },
+    /**
+     * Check if converted image exists
+     * @returns {boolean}
+     */
+    checkFileExists(imagePath) {
+      const fileExists = fs.existsSync(imagePath)
+      return fileExists
+    },
+    checkIfFile() {
+      return fs.statSync(this.path).isFile()
+    },
+    diffFiles(fileOne, fileTwo) {
+      const f1 = fs.readFileSync(fileOne)
+      const f2 = fs.readFileSync(fileTwo)
+      return f1.equals(f2)
+    },
+    dateModified(file) {
+      return fs.statSync(file).mtime
+    },
+    dateDiff(file) {
+      const now = new Date().getTime()
+      const then = this.dateModified(file).getTime()
+      return Math.round(Math.abs((then - now) / 86400000))
+    },
+    async convertAndCopy() {
+      await convertFile(this.path, {
+        height: 32,
+        width: 32,
+        outputFilePath: this.convertPath,
+      }).then((outputFile) => {
+        console.log(`SVG Converted: ${outputFile}`)
+      })
+    },
+    processFile() {
+      // Setup variables.
+      const ext = this.getFileExtension()
+
+      // If SVG, run checks.
+      if (ext === '.svg') {
+        // Check if converted file exists.
+        const convertFilePath = this.getConvertFileName()
+        if (this.checkFileExists(convertFilePath)) {
+          // If file has changed in past 7 days.
+          if (this.dateDiff(this.path) > 8) {
+            console.log(`File exists, skipping: ${this.id}`)
+            return null
+          }
+        }
+        // Convert and copy file.
+        this.convertAndCopy()
+      } else {
+        // If PNG or other, just copy the file as-is.
+        // eslint-disable-next-line no-lonely-if
+        if (this.checkIfFile()) {
+          this.copyFiles(this.path, this.convertPath)
+        } else {
+          console.info('Not a file, skipping...')
+        }
+      }
+    },
+  }
+
+  image.processFile()
+})
+
+/**
+
+cd  ; cp *.svg converted ; cd converted ; convert-svg-to-png *.svg --width 32 --height 32 ; rm *.svg
+(async() => {
+  const inputFilePath = '/path/to/my-image.svg';
+  const outputFilePath = await convertFile(inputFilePath);
+
+  console.log(outputFilePath);
+  //=> "/path/to/my-image.png"
+})();
+*/

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint src/**/*.{js,json}",
     "lint:fix": "eslint --fix src/**/*.{js,json}",
     "validate": "yarn run lint && jsonlint -qV ./schema.json ./src/technologies.json && node ./bin/validate.js",
-    "convert": "cd ./src/drivers/webextension/images/icons ; cp *.svg converted ; cd converted ; convert-svg-to-png *.svg --width 32 --height 32 ; rm *.svg",
+    "convert": "node ./bin/convert.js",
     "prettify": "jsonlint -si --trim-trailing-commas --enforce-double-quotes ./src/technologies.json",
     "build": "yarn run link && yarn run validate && yarn run prettify && yarn run convert && node ./bin/build.js",
     "build:safari": "xcrun safari-web-extension-converter --swift --project-location build --force src/drivers/webextension"


### PR DESCRIPTION
After running multiple builds lately for testing, the build time was taking an atrocious amount of time to run. Seeing that the bulk of the build was relying on the SVG conversion shell commands, I thought I would attempt to convert that to a Node script that was a little more efficient. Based on the timings below, we're seeing roughly a 95% decrease in build time, going from over 5 minutes to just under 14 seconds.

**Before**
```
yarn build  50.41s user 15.09s system 20% cpu 5:23.98 total
```

**After**
```
yarn build  7.99s user 2.18s system 73% cpu 13.818 total
```

- Convert bash script to Node script
- If PNG, copy over as-is, don't check
- Loop through SVGs and check if the converted file exists
- Check if SVG source file has recently changed. If it has, then convert it, else just skip it.

There's still some work to be done on efficiencies and a Node warning I'm seeing related to the promises for when SVGs are being converted, but overall it looks promising.

```
(node:2371) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added to [process]. Use emitter.setMaxListeners() to increase limit
(node:2371) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGINT listeners added to [process]. Use emitter.setMaxListeners() to increase limit
```