### PR TITLE
Add plain/text detection

### DIFF
--- a/src/drivers/webextension/js/driver.js
+++ b/src/drivers/webextension/js/driver.js
@@ -267,13 +267,7 @@ const Driver = {
             )
           })
 
-          if (
-            headers['content-type'] &&
-            (/\/x?html/.test(headers['content-type'][0]) ||
-              /\/plain/.test(headers['content-type'][0]))
-          ) {
-            await Driver.onDetect(request.url, analyze({ headers }))
-          }
+          await Driver.onDetect(request.url, analyze({ headers }))
         }
       } catch (error) {
         Driver.error(error)

--- a/src/drivers/webextension/js/driver.js
+++ b/src/drivers/webextension/js/driver.js
@@ -269,7 +269,8 @@ const Driver = {
 
           if (
             headers['content-type'] &&
-            /\/x?html/.test(headers['content-type'][0])
+            (/\/x?html/.test(headers['content-type'][0]) ||
+              /\/plain/.test(headers['content-type'][0]))
           ) {
             await Driver.onDetect(request.url, analyze({ headers }))
           }


### PR DESCRIPTION
While there are many MIME types that could be detected, `text/plain` should likely be added as it's a common response type from web servers, whether it's a raw file or API response.

fixes #2971