### PR TITLE
Fix Uscreen icon and validation failure

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -17479,7 +17479,7 @@
       "js": {
         "analyticsHost": "stats\\.uscreen\\.io" 
       },
-      "icon": "Uscreen.svg",
+      "icon": "Uscreen.png",
       "website": "https://uscreen.tv/",
       "pricing": [
         "mid",


### PR DESCRIPTION
- Uscreen icon is actually a PNG not an SVG. See https://github.com/AliasIO/wappalyzer/runs/1738572810 validation failure. Actual icon: `\Wappalyzer\src\drivers\webextension\images\icons\Uscreen.png`

`Error: No such icon: Uscreen.svg (Uscreen)`

The issue was introduced in https://github.com/AliasIO/wappalyzer/pull/3725 which was merged despite failing validation. You should probably set a branch protection rule which requires validation to be passing in order for PRs to be merged.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>