### PR TITLE
Change "Iubenda" to "iubenda"

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -8423,7 +8423,7 @@
       ],
       "website": "https://isotope.metafizzy.co"
     },
-    "Iubenda": {
+    "iubenda": {
       "cats": [
         67
       ],


### PR DESCRIPTION
[The correct name is "iubenda" (with lower case "i"), not "Iubenda"](https://www.iubenda.com/en/help/158-imprintimpressum-2)