### PR TITLE
Detect XHR request against Sanity API

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -14966,6 +14966,10 @@
           }
         }
       },
+      "headers": {
+        "x-sanity-shard": ""
+      },
+      "xhr": "api(cdn)?\\.sanity\\.io",
       "icon": "Sanity.svg",
       "pricing": [
         "freemium",

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -14969,7 +14969,7 @@
       "headers": {
         "x-sanity-shard": ""
       },
-      "xhr": "api(cdn)?\\.sanity\\.io",
+      "xhr": "api(?:cdn)?\\.sanity\\.io",
       "icon": "Sanity.svg",
       "pricing": [
         "freemium",


### PR DESCRIPTION
It's very common for websites using Sanity as a backend to run queries against the API using XHR/fetch. This PR adds support for detecting these requests, in the case where the site doesn't use any file/image assets.

API calls are either sent to `<projectId>.api.sanity.io` or `<projectId>.apicdn.sanity.io`. In some cases, reverse proxies are put in front of the APIs for more fine-grained cache control, in which case checking the response for `x-sanity-shard` usually detects it as being from Sanity, except if stripped in the reverse proxy.
