### PR TITLE
Improve Yoast SEO detection

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -20537,13 +20537,13 @@
       "cats": [
         54
       ],
-      "description": "Yoast SEO is a search engine optimization plug-in for WordPress.",
+      "description": "Yoast SEO is a search engine optimization plugin for WordPress and other platforms.",
       "html": [
-        "<!-- This site is optimized with the Yoast (?:WordPress )?SEO plugin v([\\d.]+) -\\;version:\\1"
+        "<!-- This site is optimized with the Yoast (?:WordPress )?SEO plugin v([\\d.]+) -\\;version:\\1",
+        "<script type=\"application/ld+json\" class=\"yoast-schema-graph\">"
       ],
       "icon": "Yoast SEO.png",
-      "implies": "WordPress",
-      "website": "http://yoast.com"
+      "website": "https://yoast.com"
     },
     "Yottaa": {
       "cats": [

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -20538,9 +20538,13 @@
         54
       ],
       "description": "Yoast SEO is a search engine optimization plugin for WordPress and other platforms.",
-      "html": [
-        "<!-- This site is optimized with the Yoast (?:WordPress )?SEO plugin v([\\d.]+) -\\;version:\\1",
-        "<script type=\"application/ld+json\" class=\"yoast-schema-graph\">"
+      "html": "<!-- This site is optimized with the Yoast (?:WordPress )?SEO plugin v([\\d.]+) -\\;version:\\1",
+      "dom": {
+        "script.yoast-schema-graph": {
+          "attributes": {
+            "class": ""
+          }
+        }
       ],
       "icon": "Yoast SEO.png",
       "website": "https://yoast.com"


### PR DESCRIPTION
Some sites filter out the "optimized with" comment, adding the `script` tag recognition will improve detection.

Since Yoast SEO also exists for other platforms, the "implies WordPress" bit isn't true.