### PR TITLE
insert back removed jquery regexes

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -23502,7 +23502,9 @@
       "description": "jQuery is a JavaScript library which is a free, open-source software designed to simplify HTML DOM tree traversal and manipulation, as well as event handling, CSS animation, and Ajax.",
       "icon": "jQuery.svg",
       "js": {
-        "jQuery.fn.jquery": "([\\d.]+)\\;version:\\1"
+        "jQuery.fn.jquery": "([\\d.]+)\\;version:\\1",
+        "$().jquery": "([\\d.]+)\\;version:\\1",
+        "$.fn.jquery": "([\\d.]+)\\;version:\\1"
       },
       "scripts": [
         "jquery[.-]([\\d.]*\\d)[^/]*\\.js\\;version:\\1",

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -23502,14 +23502,12 @@
       "description": "jQuery is a JavaScript library which is a free, open-source software designed to simplify HTML DOM tree traversal and manipulation, as well as event handling, CSS animation, and Ajax.",
       "icon": "jQuery.svg",
       "js": {
-        "jQuery.fn.jquery": "([\\d.]+)\\;version:\\1",
-        "$().jquery": "([\\d.]+)\\;version:\\1",
+        "jQuery.fn.jquery": "([\\d.]+)\\;version:\\1"
         "$.fn.jquery": "([\\d.]+)\\;version:\\1"
       },
       "scripts": [
-        "jquery[.-]([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
-        "/([\\d.]+)/jquery(?:\\.min)?\\.js\\;version:\\1",
-        "jquery.*\\.js(?:\\?ver(?:sion)?=([\\d.]+))?\\;version:\\1"
+        "/jquery(-(\\d+\\.\\d+\\.\\d+))[/.-];version:\\1",
+        "/(\\d+\\.\\d+\\.\\d+)/jquery[/.-];version:\\1"
       ],
       "website": "https://jquery.com"
     },

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -23502,7 +23502,7 @@
       "description": "jQuery is a JavaScript library which is a free, open-source software designed to simplify HTML DOM tree traversal and manipulation, as well as event handling, CSS animation, and Ajax.",
       "icon": "jQuery.svg",
       "js": {
-        "jQuery.fn.jquery": "([\\d.]+)\\;version:\\1"
+        "jQuery.fn.jquery": "([\\d.]+)\\;version:\\1",
         "$.fn.jquery": "([\\d.]+)\\;version:\\1"
       },
       "scripts": [

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -23504,7 +23504,11 @@
       "js": {
         "jQuery.fn.jquery": "([\\d.]+)\\;version:\\1"
       },
-      "scripts": "jquery",
+      "scripts": [
+        "jquery[.-]([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
+        "/([\\d.]+)/jquery(?:\\.min)?\\.js\\;version:\\1",
+        "jquery.*\\.js(?:\\?ver(?:sion)?=([\\d.]+))?\\;version:\\1"
+      ],
       "website": "https://jquery.com"
     },
     "jQuery DevBridge Autocomplete": {

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -23506,6 +23506,7 @@
         "$.fn.jquery": "([\\d.]+)\\;version:\\1"
       },
       "scripts": [
+        "jquery",
         "/jquery(-(\\d+\\.\\d+\\.\\d+))[/.-];version:\\1",
         "/(\\d+\\.\\d+\\.\\d+)/jquery[/.-];version:\\1"
       ],


### PR DESCRIPTION
The previous "scripts"-regexes (present until v6.6.0) were removed and replaced with "jquery". For me the version detection has declined due to this change. May I ask, what is the reason behind this? If I have missed something, sorry for bothering and feel free to close this proposed change. 

Thanks in advance