### PR TITLE
Ghost is a CMS

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -7853,6 +7853,7 @@
     },
     "Ghost": {
       "cats": [
+        1,
         11
       ],
       "description": "Ghost is a free and open-source blogging platform written in JavaScript, designed to simplify the process of online publishing for individual bloggers as well as online publications.",


### PR DESCRIPTION
Ghost calls itself a publishing platform, so calling it just a blog is not really correct.