### PR TITLE
Change Builder to Builder.io

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -3947,7 +3947,7 @@
       },
       "website": "http://www.bugzilla.org"
     },
-    "Builder": {
+    "Builder.io": {
       "cats": [
         1
       ],


### PR DESCRIPTION
We've been using Builder and Builder.io interchangeably in our online communications, we'd like to move to just using `Builder.io` , thank you