### PR TITLE
Fixed the identification for Hubspot consent functionality

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -9951,13 +9951,10 @@
       "cats": [
         67
       ],
-      "description": "HubSpot Cookie is a cookie compliance tool from HubSpot.",
+      "description": "HubSpot Cookie Policy banner is a cookie compliance functionality from HubSpot.",
       "icon": "HubSpot.png",
-      "js": {
-        "_hsp": ""
-      },
-      "scripts": "js\\.hs-banner\\.com/\\d+\\.js",
-      "website": "https://knowledge.hubspot.com/reports/what-cookies-does-hubspot-set-in-a-visitor-s-browser"
+      "dom": "#hs-eu-cookie-confirmation",
+      "website": "https://knowledge.hubspot.com/reports/customize-your-cookie-tracking-settings-and-privacy-policy-alert"
     },
     "Hugo": {
       "cats": [

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -9947,7 +9947,7 @@
       "scripts": "js\\.usemessages\\.com",
       "website": "https://www.hubspot.com/products/crm/live-chat"
     },
-    "HubSpot Cookie": {
+    "HubSpot Cookie Policy Banner": {
       "cats": [
         67
       ],


### PR DESCRIPTION
See discussion here: https://github.com/HTTPArchive/almanac.httparchive.org/issues/2292

Before: JS variable and request mentioned were always available for HubSpot Analytics tech.
Now: querying for the actual node of the banner.