### PR TITLE
Fixed 'Salesforce commerce cloud'  / 'Orckestra' / 'Borderfree' / Added 'Reviews' and 'Translation' categories

### DIFF
--- a/src/drivers/webextension/_locales/ca/messages.json
+++ b/src/drivers/webextension/_locales/ca/messages.json
@@ -179,5 +179,9 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
+
+
 }

--- a/src/drivers/webextension/_locales/de/messages.json
+++ b/src/drivers/webextension/_locales/de/messages.json
@@ -179,5 +179,7 @@
   "categoryName85":                  { "message": "Feature management" },
   "categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/el/messages.json
+++ b/src/drivers/webextension/_locales/el/messages.json
@@ -175,5 +175,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/en/messages.json
+++ b/src/drivers/webextension/_locales/en/messages.json
@@ -177,5 +177,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/es/messages.json
+++ b/src/drivers/webextension/_locales/es/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/fa/messages.json
+++ b/src/drivers/webextension/_locales/fa/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/fr/messages.json
+++ b/src/drivers/webextension/_locales/fr/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/gl_ES/messages.json
+++ b/src/drivers/webextension/_locales/gl_ES/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/gr/messages.json
+++ b/src/drivers/webextension/_locales/gr/messages.json
@@ -175,5 +175,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/id/messages.json
+++ b/src/drivers/webextension/_locales/id/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/it/messages.json
+++ b/src/drivers/webextension/_locales/it/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/ja/messages.json
+++ b/src/drivers/webextension/_locales/ja/messages.json
@@ -177,5 +177,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/ko/messages.json
+++ b/src/drivers/webextension/_locales/ko/messages.json
@@ -177,5 +177,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/nl/messages.json
+++ b/src/drivers/webextension/_locales/nl/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/pl/messages.json
+++ b/src/drivers/webextension/_locales/pl/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/pt/messages.json
+++ b/src/drivers/webextension/_locales/pt/messages.json
@@ -179,5 +179,7 @@
   "categoryName85":                  { "message": "Feature management" },
   "categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/pt_BR/messages.json
+++ b/src/drivers/webextension/_locales/pt_BR/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/ro/messages.json
+++ b/src/drivers/webextension/_locales/ro/messages.json
@@ -175,5 +175,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/ru/messages.json
+++ b/src/drivers/webextension/_locales/ru/messages.json
@@ -175,7 +175,7 @@
 	"categoryName83":                  { "message": "Отпечатки браузера" },
 	"categoryName84":                  { "message": "Программы лояльности и наград" },
 	"categoryName85":                  { "message": "Управление функциями" },
-	"categoryName86":                  { "message": "Сегментация" }
+	"categoryName86":                  { "message": "Сегментация" },
 	"categoryName87":                  { "message": "WordPress plugins" },
 	"categoryName88":                  { "message": "Hosting" },
 	"categoryName89":                  { "message": "Translation" },

--- a/src/drivers/webextension/_locales/ru/messages.json
+++ b/src/drivers/webextension/_locales/ru/messages.json
@@ -176,4 +176,8 @@
 	"categoryName84":                  { "message": "Программы лояльности и наград" },
 	"categoryName85":                  { "message": "Управление функциями" },
 	"categoryName86":                  { "message": "Сегментация" }
+	"categoryName87":                  { "message": "WordPress plugins" },
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/sk/messages.json
+++ b/src/drivers/webextension/_locales/sk/messages.json
@@ -179,5 +179,7 @@
   "categoryName85":                  { "message": "Feature management" },
   "categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/tr/messages.json
+++ b/src/drivers/webextension/_locales/tr/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/uk/messages.json
+++ b/src/drivers/webextension/_locales/uk/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/uz/messages.json
+++ b/src/drivers/webextension/_locales/uz/messages.json
@@ -179,5 +179,7 @@
 	"categoryName85":                  { "message": "Feature management" },
 	"categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/zh_CN/messages.json
+++ b/src/drivers/webextension/_locales/zh_CN/messages.json
@@ -175,5 +175,7 @@
   "categoryName85":                  { "message": "Feature management" },
   "categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/drivers/webextension/_locales/zh_TW/messages.json
+++ b/src/drivers/webextension/_locales/zh_TW/messages.json
@@ -179,5 +179,7 @@
   "categoryName85":                  { "message": "Feature management" },
   "categoryName86":                  { "message": "Segmentation" },
 	"categoryName87":                  { "message": "WordPress plugins" },
-	"categoryName88":                  { "message": "Hosting" }
+	"categoryName88":                  { "message": "Hosting" },
+	"categoryName89":                  { "message": "Translation" },
+	"categoryName90":                  { "message": "Reviews" }
 }

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -18496,8 +18496,7 @@
       "icon": "Salesforce.svg",
       "implies": "Salesforce",
       "js": {
-        "dwAnalytics": "",
-        "dw": ""
+        "dwAnalytics": ""
       },
       "pricing": [
         "poa"

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -3661,7 +3661,8 @@
       "scripts": [
         "global\\.prd\\.borderfree\\.com",
         "wm\\.prd\\.borderfree\\.com",
-        "bfx\\.js"
+        "bfx\\.js",
+        "cbt\\.js"
       ],
       "website": "https://www.borderfree.com"
     },
@@ -15290,6 +15291,10 @@
         6
       ],
       "description": "Orckestra is a provider of cloud-based digital unified and omnichannel commerce solutions for retail and manufacturing industries.",
+      "headers": {
+        "x-powered-by": "Orckestra",
+        "x-orckestra-commerce": ".NET Client"
+      },      
       "icon": "Orckestra.svg",
       "implies": "Microsoft ASP.NET",
       "meta": {
@@ -18473,17 +18478,19 @@
       "cats": [
         6
       ],
-      "description": "Salesforce Commerce Cloud is a cloud-based software-as-a-service (SaaS) ecommerce solution.",
+      "cookies": {
+        "dwsid": "",
+        "dw_dnt": ""
+      },      
+      "description": "Salesforce Commerce Cloud is a cloud-based software-as-a-service (SaaS) ecommerce solution.",      
       "headers": {
         "Server": "Demandware eCommerce Server"
       },
-      "html": [
-        "<[^>]+demandware\\.edgesuite"
-      ],
       "icon": "Salesforce.svg",
       "implies": "Salesforce",
       "js": {
-        "dwAnalytics": ""
+        "dwAnalytics": "",
+        "dw": ""
       },
       "pricing": [
         "poa"

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -340,7 +340,15 @@
     "88": {
       "name": "Hosting",
       "priority": 9
-    }
+    },
+    "89": {
+      "name": "Translation",
+      "priority": 9
+    },
+    "90": {
+      "name": "Reviews",
+      "priority": 9
+    }    
   },
   "technologies": {
     "1C-Bitrix": {
@@ -2955,8 +2963,7 @@
     },
     "Bablic": {
       "cats": [
-        3,
-        9
+        89
       ],
       "description": "Bablic is a localisation solution to translate your website.",
       "icon": "bablic.png",
@@ -23768,7 +23775,7 @@
     },
     "Weglot": {
       "cats": [
-        19
+        89
       ],
       "headers": {
         "Weglot-Translated": ""


### PR DESCRIPTION
Updated for following -

- Fixed for 'Salesforce commerce cloud' false positives (https://github.com/AliasIO/wappalyzer/issues/4090)
- Improved detected for 'Orckestra' (https://github.com/AliasIO/wappalyzer/issues/4362) and 'Borderfree' (https://github.com/AliasIO/wappalyzer/issues/4356)