### PR TITLE
Fix `core-js` detection

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -5618,7 +5618,8 @@
         "__core-js_shared__": "",
         "__core-js_shared__.versions.0.version": "^(.+)$\\;version:\\1",
         "core": "",
-        "core.version": "^(.+)$\\;version:\\1"
+        "core.version": "^(.+)$\\;version:\\1",
+        "_babelPolyfill": ""
       },
       "oss": true,
       "website": "https://github.com/zloirock/core-js"
@@ -16606,8 +16607,7 @@
       ],
       "icon": "polyfill.svg",
       "scripts": [
-        "^https?://cdn\\.polyfill\\.io/",
-        "/polyfill\\.min\\.js"
+        "^https?://cdn\\.polyfill\\.io/"
       ],
       "website": "https://polyfill.io"
     },

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -5615,6 +5615,9 @@
       ],
       "description": "core-js is a modular standard library for JavaScript, with polyfills for cutting-edge ECMAScript features.",
       "js": {
+        "__core-js_shared__": "",
+        "__core-js_shared__.versions.0.version": "^(.+)$\\;version:\\1",
+        "core": "",
         "core.version": "^(.+)$\\;version:\\1"
       },
       "oss": true,

--- a/src/technologies.json
+++ b/src/technologies.json
@@ -5616,7 +5616,7 @@
       "description": "core-js is a modular standard library for JavaScript, with polyfills for cutting-edge ECMAScript features.",
       "js": {
         "__core-js_shared__": "",
-        "__core-js_shared__.versions.0.version": "^(.+)$\\;version:\\1",
+        "__core-js_shared__.versions[0].version": "^(.+)$\\;version:\\1",
         "core": "",
         "core.version": "^(.+)$\\;version:\\1",
         "_babelPolyfill": ""


### PR DESCRIPTION
In #4421 was added `core-js` detection, but it misses the most of cases.

The global `core` variable was available to `core-js@2` in *some* cases.

The global `__core-js_shared__` property is available in modern versions in *most* cases.

The `.version` and `.versions` properties are available only in modern versions.

`window['__core-js_shared__'].versions` contains information about all loaded `core-js` versions and modes, but I have no ideas how to handle it with your regex syntax.

![image](https://user-images.githubusercontent.com/2213682/130413404-7a2eb52e-84ba-48d4-8493-9d6c86cc53f8.png)

My detection script https://github.com/zloirock/core-js/blob/5ddafd1/scripts/usage.mjs

Top 1000 results https://gist.github.com/zloirock/7331cec2a1ba74feae09e64584ec5d0e

Top 10000 results https://gist.github.com/zloirock/1fae0b9798b50d3551432ebf100216b9