### PR TITLE
fix websocket detection

### DIFF
--- a/src/technologies.json
+++ b/src/technologies.json
@@ -23945,10 +23945,7 @@
       "cats": [
         19
       ],
-      "html": [
-        "<link[^>]+rel=[\"']web-socket[\"']",
-        "<(?:link|a)[^>]+href=[\"']wss?://"
-      ],
+	  "js": {"WebSocket":""},
       "icon": "websocket.png",
       "website": "https://en.wikipedia.org/wiki/WebSocket"
     },


### PR DESCRIPTION
Websocket API is a Web IDL standardized by the W3C. It is a JavaScript API and therefore is better detected using js. The current detection is based on a ws/wss url being present in the html, but this is not at all a requirement.

I based the new rule on the WebSocket object. "In order to communicate using the WebSocket protocol, you need to create a WebSocket object". ([mdn](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications#creating_a_websocket_object))


I went through the list of detections in [websocket](https://www.wappalyzer.com/technologies/miscellaneous/websocket/) and the previous detections are still working.
An example for currently missing detections can be found in [socket.io](https://www.wappalyzer.com/technologies/javascript-frameworks/socket-io/) detections which is a framework for dealing with websocket and therefore should imply websocket. It is now detected as websocket as well as socket.io
