### PR TITLE
Fix regex brackets for MaxMind

### DIFF
--- a/src/technologies/m.json
+++ b/src/technologies/m.json
@@ -486,7 +486,7 @@
     ],
     "saas": true,
     "scripts": [
-      "[device|js]\\.maxmind\\.com/",
+      "(?:device|js)\\.maxmind\\.com/",
       "geoip\\.maxmind\\.min\\.js"
     ],
     "website": "https://www.maxmind.com",


### PR DESCRIPTION
The brackets used in the regex for MaxMind were wrong: they would match the _characters_ from the words `device`/`js`, not the full word.