### PR TITLE
Fix Drupal Multisite (false positive)

### DIFF
--- a/src/technologies/d.json
+++ b/src/technologies/d.json
@@ -826,7 +826,7 @@
     "implies": "Drupal",
     "oss": true,
     "scripts": [
-      "sites/(?!default).*/files"
+      "sites\\/(?!default|all).*\\/files"
     ],
     "website": "https://www.drupal.org/docs/multisite-drupal"
   },


### PR DESCRIPTION
Fixing a false positive in the Drupal multisite detection (all D7 sites use sites/all path, marked for exclusion).