### PR TITLE
Invalid json in technology file (p.json)

### DIFF
--- a/src/technologies/p.json
+++ b/src/technologies/p.json
@@ -1267,7 +1267,7 @@
       "#app, .app, #root, .root, body, body > *, body > * > *, body > * > * > *": {
         "properties": {
           "__k": ""
-        },
+        }
       }
     },
     "icon": "Preact.svg",


### PR DESCRIPTION
File p.json contains invalid json (trailing comma).