### PR TITLE
Fix jquery patterns' version specifier

### DIFF
--- a/src/technologies/j.json
+++ b/src/technologies/j.json
@@ -545,8 +545,8 @@
     },
     "scripts": [
       "jquery",
-      "/jquery(-(\\d+\\.\\d+\\.\\d+))[/.-];version:\\1",
-      "/(\\d+\\.\\d+\\.\\d+)/jquery[/.-];version:\\1"
+      "/jquery(-(\\d+\\.\\d+\\.\\d+))[/.-]\\;version:\\1",
+      "/(\\d+\\.\\d+\\.\\d+)/jquery[/.-]\\;version:\\1"
     ],
     "website": "https://jquery.com"
   },


### PR DESCRIPTION
Per: https://www.wappalyzer.com/docs/dev/specification/#version-syntax the semi-colons should be escaped.