### PR TITLE
Add Shopify to CMS category

### DIFF
--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -1327,6 +1327,7 @@
   },
   "Shopify": {
     "cats": [
+      1,
       6
     ],
     "cookies": {


### PR DESCRIPTION
Shopify is defined as a CMS in [w3tech](https://w3techs.com/technologies/history_overview/content_management) and also defines itself as a CMS for example - https://www.shopify.com/tour/ecommerce-cms

We will probably include it in the CMS chapter for this year's [web almanac](https://almanac.httparchive.org/en/2020/cms)