### PR TITLE
feat: update vercel server header

### DIFF
--- a/src/technologies/v.json
+++ b/src/technologies/v.json
@@ -198,7 +198,7 @@
       22
     ],
     "headers": {
-      "server": "^now$",
+      "server": "^now|Vercel$",
       "x-now-trace": "",
       "x-vercel-cache": "",
       "x-vercel-id": ""


### PR DESCRIPTION
Vercel also uses the `server: Vercel` header.

Check it via: `curl -sI https://vercel.com/ | grep server:`
