### PR TITLE
Add GoDaddy Escapade / WordPress theme

### DIFF
--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -672,6 +672,17 @@
     "icon": "GoCache.png",
     "website": "https://www.gocache.com.br/"
   },
+  "GoDaddy Escapade": {
+    "cats": [
+      80
+    ],
+    "description": "GoDaddy Escapade is a GoDaddy Primer child theme with a unique sidebar navigation.",
+    "dom": "link[href*='/wp-content/themes/escapade/']",
+    "excludes": "GoDaddy Primer",
+    "icon": "GoDaddy.svg",
+    "requires": "WordPress",
+    "website": "https://github.com/godaddy-wordpress/primer-child-escapade"
+  },
   "GoDaddy Go": {
     "cats": [
       80


### PR DESCRIPTION
### website:
https://github.com/godaddy-wordpress/primer-child-escapade
### examples:
http://troysskishop.com/
http://liveurlinkc.com/
http://idaff.com/
https://www.solostroup.com/wp/