### PR TITLE
updated the jsonlint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "link": "node ./bin/link.js",
     "lint": "eslint src/**/*.{js,json}",
     "lint:fix": "eslint --fix src/**/*.{js,json}",
-    "validate": "yarn run lint && jsonlint -qV ./schema.json ./src/technologies/*.json && node ./bin/validate.js",
+    "validate": "yarn run lint && jsonlint -qV ./schema.json ./src/technologies/ && node ./bin/validate.js",
     "convert": "node ./bin/convert.js",
     "prettify": "jsonlint -si --trim-trailing-commas --enforce-double-quotes ./src/categories.json ./src/technologies/*.json",
     "build": "yarn run link && yarn run validate && yarn run prettify && yarn run convert && node ./bin/build.js",


### PR DESCRIPTION
 #5024
Updated jsonlint -qV ./src/technologies/*.json to jsonlint -qV ./src/technologies/
According to https://github.com/prantlf/jsonlint#readme that is all that is needed to check all json files within a directory. This takes care of the warning. I tested it out by messing up a few json files and it is working as expected. Please review and merge.