### PR TITLE
Add Huberway Analytics / analytics

### DIFF
--- a/src/technologies/h.json
+++ b/src/technologies/h.json
@@ -695,6 +695,19 @@
     "saas": true,
     "website": "https://www.huberway.com"
   },
+  "Huberway Analytics": {
+    "cats": [
+      10
+    ],
+    "description": "Huberway Analytics is a free web analytics service that tracks and reports website traffic.",
+    "icon": "Huberway.svg",
+    "scriptSrc": "analytics\\.huberway\\.com/pixel/",
+    "pricing": [
+      "freemium"
+    ],
+    "saas": true,
+    "website": "https://www.huberway.com/analytics-software"
+  },
   "Hugo": {
     "cats": [
       57


### PR DESCRIPTION
### website:
https://www.huberway.com/analytics-software
### examples:
https://www.foodclub.it/
https://svapohub.com/
https://tammarometalli.com/home