### PR TITLE
Fix Vercel category

### DIFF
--- a/src/technologies/v.json
+++ b/src/technologies/v.json
@@ -195,7 +195,7 @@
   },
   "Vercel": {
     "cats": [
-      22
+      62
     ],
     "headers": {
       "server": "^now|Vercel$",


### PR DESCRIPTION
Vercel was previously under the "web server" category, but they are actually a Platform that runs Next.js servers.