### PR TITLE
Dart shouldn't imply AngularDart

### DIFF
--- a/src/technologies/d.json
+++ b/src/technologies/d.json
@@ -187,7 +187,6 @@
     ],
     "html": "/(?:<script)[^>]+(?:type=\"application/dart\")/",
     "icon": "Dart.svg",
-    "implies": "AngularDart",
     "js": {
       "___dart__$dart_dartObject_ZxYxX_0_": "",
       "___dart_dispatch_record_ZxYxX_0_": ""


### PR DESCRIPTION
Dart can be used (on the web) on its own without AngularDart.

Links:
- https://dart.dev/guides/libraries#web-platform-libraries
- https://vuedart.dev/
- https://workiva.github.io/over_react/
- https://vite-plugin-dart.vercel.app/
- https://flutter.dev/web

Additionally, AngularDart is slowly dying (at least community wise) due to Flutter supporting web.
- https://github.com/angulardart/angular/pulse
- https://www.reddit.com/r/dartlang/comments/djm4ix/what_is_the_current_state_of_angulardart/f47s39v/ (comment made on Oct 2018)
