### PR TITLE
Add Jetpack / WP plugin

### DIFF
--- a/src/drivers/webextension/images/icons/Jetpack.svg
+++ b/src/drivers/webextension/images/icons/Jetpack.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 0C7.2 0 0 7.2 0 16C0 24.8 7.2 32 16 32C24.8 32 32 24.8 32 16C32 7.2 24.8 0 16 0Z" fill="#069E08"/>
+<path d="M15 19H7L15 3V19Z" fill="white"/>
+<path d="M17 29V13H25L17 29Z" fill="white"/>
+</svg>

--- a/src/technologies/j.json
+++ b/src/technologies/j.json
@@ -257,6 +257,22 @@
     },
     "website": "https://jenkins.io/"
   },
+  "Jetpack": {
+    "cats": [
+      87
+    ],
+    "description": "Jetpack is a popular WordPress plugin created by Automattic, the people behind WordPress.com.",
+    "dom": "link[href*='/wp-content/plugins/jetpack/']",
+    "icon": "Jetpack.svg",
+    "pricing": [
+      "freemium",
+      "low",
+      "recurring"
+    ],
+    "requires": "WordPress",
+    "scriptSrc": "/wp-content/plugins/jetpack/",
+    "website": "https://jetpack.com"
+  },
   "Jetshop": {
     "cats": [
       6


### PR DESCRIPTION
### website:
https://jetpack.com/
### examples:
https://www.caasimada.net/
https://www.hardware.com.br/
https://boardingarea.com/
http://1000mg.jp/
https://www.americaspace.com/
https://appmedia.jp/
https://www.rvcj.com/
https://paultan.org/
https://joinhandshake.com/