### PR TITLE
Update cart functionality

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -342,7 +342,19 @@
       6
     ],
     "description": "Websites that have a shopping cart or checkout page, either using a known ecommerce platform or a custom solution.",
-    "dom": "a[href*='/cart'], a[href*='/order'], a[href*='/basket'], a[href*='/trolley'], a[href*='/bag'], a[href*='/shoppingbag'], a[href*='/checkout'], [aria-controls='cart']",
+    "dom": [
+      "a[href*='/cart']",
+      "a[href*='/order']",
+      "a[href*='/basket']",
+      "a[href*='/trolley']",
+      "a[href*='/bag']",
+      "a[href*='/shoppingbag']",
+      "a[href*='/checkout']",
+      "[aria-controls='cart']",
+      "*[class*='shopping-bag']",
+      "*[class*='shopping-cart']",
+      "*[class*='checkout']"
+    ],
     "icon": "Cart-generic.svg",
     "js": {
       "google_tag_params.ecomm_pagetype": ""


### PR DESCRIPTION
Cart functionality is too important to be missed.

"shopping-bag/basket/cart" frequently appears in various tags, so use it.

Example: https://www.bike24.de