### PR TITLE
Add Yoast Duplicate Post / WP plugin

### DIFF
--- a/src/technologies/y.json
+++ b/src/technologies/y.json
@@ -221,6 +221,16 @@
     ],
     "website": "https://www.yiiframework.com"
   },
+  "Yoast Duplicate Post": {
+    "cats": [
+      87
+    ],
+    "description": "Yoast Duplicate Post is a WordPress plugin which allows users to clone posts of any type, or copy them to new drafts for further editing.",
+    "icon": "Yoast SEO.png",
+    "requires": "WordPress",
+    "dom": "link[href*='/wp-content/plugins/duplicate-post/']",
+    "website": "https://wordpress.org/plugins/duplicate-post"
+  },
   "Yoast SEO": {
     "cats": [
       54,


### PR DESCRIPTION
### website:
https://yoast.com/wordpress/plugins/duplicate-post/
### examples:
https://xg4ken.com/
https://www.kurashijouzu.jp/
https://www.aircargoweek.com/
https://systemrapid.com/
http://www.ostaulkomailta.com/blog/
http://milkbar-creative.com/
https://mycrowd.com/
http://www.waiwaithailand.com/
