### PR TITLE
Allow for beta version of VuePress

### DIFF
--- a/src/technologies/v.json
+++ b/src/technologies/v.json
@@ -577,7 +577,7 @@
     "icon": "VuePress.svg",
     "implies": "Vue.js",
     "meta": {
-      "generator": "^VuePress(?: ([0-9.]+))?$\\;version:\\1"
+      "generator": "^VuePress(?: ([0-9.]+)(-[a-z]+.[0-9]+)?)?$\\;version:\\1"
     },
     "website": "https://vuepress.vuejs.org/"
   },


### PR DESCRIPTION
Meta tag: `<meta name="generator" content="VuePress 2.0.0-beta.27">`

Example
- https://v2.vuepress.vuejs.org/