### PR TITLE
Add GoDaddy CoBlocks / WP plugin, page builder

### DIFF
--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -672,6 +672,22 @@
     "icon": "GoCache.png",
     "website": "https://www.gocache.com.br/"
   },
+  "GoDaddy CoBlocks": {
+    "cats": [
+      87,
+      51
+    ],
+    "description": "GoDaddy CoBlocks is a suite of professional page building content blocks for the WordPress Gutenberg block editor.",
+    "icon": "GoDaddy.svg",
+    "dom": "link[href*='/wp-content/plugins/coblocks/']",
+    "pricing": [
+      "freemium"
+    ],
+    "requires": "WordPress",
+    "oss": true,
+    "scriptSrc": "/wp-content/plugins/coblocks/",
+    "website": "https://github.com/godaddy-wordpress/coblocks"
+  },
   "GoDaddy Escapade": {
     "cats": [
       80


### PR DESCRIPTION
### website:
https://github.com/godaddy-wordpress/coblocks
### examples:
https://www.utdallas.edu/
https://edublogs.org/
https://www.prontonetworks.com/
https://www.optimalworkshop.com/
https://mh.gob.sv/
https://mh.gob.sv/
https://www.galileo.edu/
https://digitalrev.com/
https://enviragallery.com/
https://norml.org/