### PR TITLE
Fix Invalid CSS selector pattern

### DIFF
--- a/src/technologies/p.json
+++ b/src/technologies/p.json
@@ -1629,7 +1629,7 @@
       80
     ],
     "description": "Press Hueman is a mobile friendly WordPress theme for blogs, magazines and business websites.",
-    "dom": "link[*='/wp-content/themes/hueman/']",
+    "dom": "link[href*='/wp-content/themes/hueman/']",
     "icon": "Press.svg",
     "js": {
       "HUParams": ""


### PR DESCRIPTION
previously: `link[*='/wp-content/themes/hueman/']`

Now: `link[href*='/wp-content/themes/hueman/']`


When I was processing this pattern in another place, I was gettting this error:

![image](https://user-images.githubusercontent.com/18349557/142628491-e3d36a60-1642-40a1-b3f3-aed2a1c750ff.png)
