### PR TITLE
Update Google Sites / CMS

### DIFF
--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -1146,6 +1146,7 @@
     ],
     "icon": "Google Sites.png",
     "url": "^https?://sites\\.google\\.com",
+    "dom": "[data-abuse-proto*='https://sites.google.com/']",
     "website": "http://sites.google.com"
   },
   "Google Tag Manager": {


### PR DESCRIPTION
Detect Google Sites that have a custom domain

### website:

http://sites.google.com

### examples:

https://toolkit.openbriefing.org/
https://ecosystem.openbriefing.org/about
https://sites.google.com/view/simpleanalytics-test-site/home

### test:

```js
document.querySelector('[data-abuse-proto*="https://sites.google.com/"]')
```