### PR TITLE
fix(driver.js): try catch status on analyse

### DIFF
--- a/src/drivers/npm/driver.js
+++ b/src/drivers/npm/driver.js
@@ -995,7 +995,9 @@ class Site {
       ])
     } catch (error) {
       this.analyzedUrls[url.href] = {
-        status: this.analyzedUrls[url.href]?.status || 0,
+        status: this.analyzedUrls[url.href]
+          ? this.analyzedUrls[url.href].status || 0
+          : 0,
         error: error.message || error.toString(),
       }
 


### PR DESCRIPTION
Error OnLine 998 of Driver.js cause cli.js crash. 