### PR TITLE
Duplicate Squarespace template version tagging for "Squarespace Commerce" websites

### DIFF
--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -3740,10 +3740,14 @@
       6
     ],
     "description": "Squarespace Commerce is an ecommerce platform designed to facilitate the creation of websites and online stores, with domain registration and web hosting included.",
+    "headers": {
+      "server": "Squarespace"
+    },
     "icon": "Squarespace.svg",
     "implies": "Squarespace",
     "js": {
-      "SQUARESPACE_ROLLUPS.squarespace-commerce": ""
+      "SQUARESPACE_ROLLUPS.squarespace-commerce": "",
+      "Static.SQUARESPACE_CONTEXT.templateVersion": "^(\\d(?:\\.\\d)?)$\\;version:\\1"
     },
     "pricing": [
       "low",


### PR DESCRIPTION
Adding some fields to Squarespace Commerce that were previously assumed to be inherited from Squarespace.