### PR TITLE
Add Cookie Information plugin / WP plugin, Cookie compliance

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -2082,6 +2082,23 @@
     "saas": true,
     "website": "https://cookieinformation.com"
   },
+  "Cookie Information plugin": {
+    "cats": [
+      87,
+      67
+    ],
+    "description": "Cookie Information plugin helps your website stay compliant with GDPR using a free cookie pop-up, consent log, and more.",
+    "icon": "Cookie Information.svg",
+    "implies": "Cookie Information",
+    "pricing": [
+      "freemium",
+      "low",
+      "recurring"
+    ],
+    "requires": "WordPress",
+    "scriptSrc": "/wp-content/plugins/wp-gdpr-compliance/",
+    "website": "https://wordpress.org/plugins/wp-gdpr-compliance"
+  },
   "Cookie Notice": {
     "cats": [
       67,


### PR DESCRIPTION
### website:
https://wordpress.org/plugins/wp-gdpr-compliance/
https://cookieinformation.com/
### examples:
https://wpbakery.com/
https://iupac.org/
https://www.americaspace.com/
https://vilmanunez.com/
https://katohika.gr/
https://www.compact-online.de/
