### PR TITLE
fix: removing implies for stitches

### DIFF
--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -3993,17 +3993,8 @@
       47
     ],
     "description": "Stitches is a is a CSS-in-JS styling framework with near-zero runtime, SSR, and multi-variant support.",
-    "dom": "style#stitches, .StudioCanvas, .publish-studio-style",
+    "dom": "style#stitches",
     "icon": "Stitches.svg",
-    "implies": [
-      "React",
-      "Next.js",
-      "Gatsby",
-      "Svelte",
-      "SvelteKit",
-      "Vue.js",
-      "Angular"
-    ],
     "meta": {
       "generator": "^c-[A-Za-z]{5}$"
     },


### PR DESCRIPTION
removing implies from stitches because it works with any js/ts framework