### PR TITLE
Add Translate WordPress / WP plugin, Translation

### DIFF
--- a/src/technologies/t.json
+++ b/src/technologies/t.json
@@ -1531,6 +1531,17 @@
     },
     "website": "https://www.transifex.com"
   },
+  "Translate WordPress": {
+    "cats": [
+      87,
+      89
+    ],
+    "description": "Translate WordPress is a website translator plugin which can translate any website to any language automatically. Translate WordPress plugin is now a part of GTranslate family.",
+    "icon": "GTranslate.svg",
+    "scriptSrc": "/wp-content/plugins/google-language-translator/.+scripts\\.js(?:\\?ver=(\\d+(?:\\.\\d+)+))?\\;version:\\1",
+    "requires": "WordPress",
+    "website": "https://gtranslate.io"
+  },
   "Translucide": {
     "cats": [
       1


### PR DESCRIPTION
### website:
https://gtranslate.io/
https://wordpress.org/plugins/google-language-translator/
### examples:
https://www.periskopi.com/
https://www.tonyelumelufoundation.org/
https://www.globalbrandsmagazine.com/
https://mikeprg.com/
https://www.sheerid.com/
https://www.jihadwatch.org/