### PR TITLE
Add Catch Themes Fotografie / WP themes

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -503,6 +503,21 @@
     "scriptSrc": "/wp-content/themes/catch-box(?:-pro)?/",
     "website": "https://catchthemes.com/themes/catch-box"
   },
+  "Catch Themes Fotografie": {
+    "cats": [
+      80
+    ],
+    "description": "Fotografie is a modern photography WordPress theme that comes with high-quality features and minimal design by Catch Themes.",
+    "dom": "link[href*='/wp-content/themes/fotografie/']",
+    "icon": "Catch Themes.png",
+    "pricing": [
+      "freemium",
+      "onetime"
+    ],
+    "requires": "WordPress",
+    "scriptSrc": "/wp-content/themes/fotografie(?:-pro)?/",
+    "website": "https://catchthemes.com/themes/fotografie"
+  },
   "Cecil": {
     "cats": [
       57


### PR DESCRIPTION
### website:
https://catchthemes.com/themes/fotografie/
### examples:
https://www.blackpast.org/
http://www.posinwang.com/
http://www.the-photography-blogger.com/
http://topgymfitness.pl/
https://lequebecunehistoiredefamille.com/
http://chomeur.net/
http://www.lagomera.com.pl/