### PR TITLE
Add Theme Freesia Photograph / WP themes

### DIFF
--- a/src/technologies/t.json
+++ b/src/technologies/t.json
@@ -746,6 +746,20 @@
     ],
     "website": "http://thelia.net"
   },
+  "Theme Freesia Photograph": {
+    "cats": [
+      80
+    ],
+    "description": "Photograph is a WordPress theme exclusively built for photographer, blogger, portfolio, photography agency or photo studio websites.",
+    "icon": "Theme Freesia.png",
+    "pricing": [
+      "freemium",
+      "onetime"
+    ],
+    "requires": "WordPress",
+    "scriptSrc": "/wp-content/themes/photograph(?:-plus)?/",
+    "website": "https://themefreesia.com/themes/Photograph"
+  },
   "Theme Freesia ShoppingCart": {
     "cats": [
       80


### PR DESCRIPTION
### website:
https://themefreesia.com/themes/Photograph/
### examples:
https://film-grab.com/
http://www.cookiecoffee.com/
https://nativegrillandwings.com/
https://ulfelderphoto.com/
https://weddinglovequotes.com/
https://mystudio.gr/