### PR TITLE
Add WEN Themes Signify Dark / WP themes

### DIFF
--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -64,6 +64,22 @@
     "scriptSrc": "/wp-content/themes/education-hub(?:-pro)?/",
     "website": "https://wenthemes.com/item/wordpress-themes/education-hub"
   },
+  "WEN Themes Signify Dark": {
+    "cats": [
+      80
+    ],
+    "description": "Signify Dark is a free dark blog and corporate WordPress theme that is trendy, responsive, and dynamic by WEN Themes.",
+    "icon": "WEN Themes.png",
+    "js": {
+      "signifyOptions": ""
+    },
+    "pricing": [
+      "freemium",
+      "onetime"
+    ],
+    "requires": "WordPress",
+    "website": "https://wenthemes.com/item/wordpress-themes/signify-dark"
+  },
   "WHMCS": {
     "cats": [
       1


### PR DESCRIPTION
### website:
https://wenthemes.com/item/wordpress-themes/signify-dark/
### examples:
http://www.wfku.org/
https://www.nosvoyants.com/
https://ecc-expo.com/
http://espikvlt.com/
http://julianassange.com/
https://www.crimeculture.com/