### PR TITLE
Add detection for Wagtail’s rich text data-block-key attributes

### DIFF
--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -331,6 +331,11 @@
     ],
     "description": "Wagtail is a Django content management system (CMS) focused on flexibility and user experience.",
     "dom": {
+      "[data-block-key]": {
+        "attributes": {
+          "data-block-key": "[a-z0-9]{5}"
+        }
+      },
       "[style*='images/']": {
         "attributes": {
           "style": "(?:\\.[a-z]+|/media)(?:/[\\w-]+)?/(?:original_images/[\\w-]+|images/[\\w-.]+\\.(?:(?:fill|max|min)-\\d+x\\d+(?:-c\\d+)?|(?:width|height|scale)-\\d+|original))\\."


### PR DESCRIPTION
This adds a way to detect Wagtail sites based on rich text content – Wagtail uses the `data-block-key` attribute so each block has a unique identifier:

```html
<li data-block-key="3so1f">This is a list item in rich text</li>
```

I’ve implemented the detection pattern I’m proposing here by testing it on homepages of [a directory of 600+ Wagtail sites](https://madewithwagtail.org/), and of the [Majestic Million](https://majestic.com/reports/majestic-million). I didn’t find any false positives – a few non-Wagtail homepages do use the same attribute name, but not the same format for values.

Here is a sample of 10 Wagtail sites’ homepages where the previous detection methods didn’t find any matches, while the `data-block-key` check does:

```
billiger.de
edge.co.uk
gandi.net
heijmans.nl
hotel-neptun.de
mplus.org.hk
mybaze.com
nga.gov.au
superbalist.com
where2golf.com
```

And here are non-Wagtail sites’ homepages I found with the same attribute but different values, which explains why we have to check for both the attribute and the values’ patterns:

```
dum-umeni.cz data-block-key="b366dfd02dc0447f83eed0e9dda2d351"
hagergroup.com data-block-key="3"
palazzoversace.ae data-block-key="home"
palazzoversace.com.au data-block-key=""
```

