### PR TITLE
update Layer0 definition to include response headers

### DIFF
--- a/src/technologies/l.json
+++ b/src/technologies/l.json
@@ -185,6 +185,11 @@
       "layer0_eid": ""
     },
     "description": "Layer0 is an all-in-one Jamstack platform to develop, deploy, preview, split test, and monitor the company's frontend.",
+    "headers": {
+      "x-0-status": "",
+      "x-0-t": "",
+      "x-0-version": ""
+    },
     "icon": "Layer0.svg",
     "js": {
       "Layer0.Metrics": ""

--- a/src/technologies/l.json
+++ b/src/technologies/l.json
@@ -188,7 +188,7 @@
     "headers": {
       "x-0-status": "",
       "x-0-t": "",
-      "x-0-version": "^\\d+ ([\\d\\.]+) .+$\\;version:\\1"
+      "x-0-version": "^\\d+ ([\\d.]+) \\;version:\\1"
     },
     "icon": "Layer0.svg",
     "js": {

--- a/src/technologies/l.json
+++ b/src/technologies/l.json
@@ -188,7 +188,7 @@
     "headers": {
       "x-0-status": "",
       "x-0-t": "",
-      "x-0-version": ""
+      "x-0-version": "^\\d+ ([\\d\\.]+) .+$\\;version:\\1"
     },
     "icon": "Layer0.svg",
     "js": {


### PR DESCRIPTION
Layer0 sites include response headers in the form of `x-0-*` (https://docs.layer0.co/guides/response_headers) which also include the version of Layer0 used to deploy the site in the `x-0-version` header.