### PR TITLE
Fix Drupal Multisite - Expand asset source detection

### DIFF
--- a/src/technologies/d.json
+++ b/src/technologies/d.json
@@ -1190,11 +1190,37 @@
       88
     ],
     "description": "Drupal Multisite enables separate, independent sites to be served from a single codebase.",
-    "html": [
-      "script[src*='sites\\/(?!default|all).*\\/files']",
-      "img[src*='sites\\/(?!default|all).*\\/files']",
-      "img[data-src*='sites\\/(?!default|all).*\\/files']",
-      "link[href*='sites\\/(?!default|all).*\\/files']"
+    "dom": {
+      "img[src*='sites/default/']": {
+        "attributes": {
+          "src": "sites\\/default\\/.*\\/files'"
+        }
+      },
+      "img[src*='sites/all/']": {
+        "attributes": {
+          "src": "sites\\/all\\/.*\\/files'"
+        }
+      },
+      "img[data-src*='sites/default/']": {
+        "attributes": {
+          "data-src": "sites\\/default\\/.*\\/files'"
+        }
+      },
+      "img[data-src*='sites/all/']": {
+        "attributes": {
+          "data-src": "sites\\/all\\/.*\\/files'"
+        }
+      },
+      "link[href*='sites/default/']": {
+        "attributes": {
+          "href": "sites\\/default\\/.*\\/files'"
+        }
+      },
+      "link[href*='sites/all/']": {
+        "attributes": {
+          "href": "sites\\/all\\/.*\\/files'"
+        }
+      }
     ],
     "icon": "Drupal.svg",
     "implies": "Drupal",

--- a/src/technologies/d.json
+++ b/src/technologies/d.json
@@ -1190,6 +1190,12 @@
       88
     ],
     "description": "Drupal Multisite enables separate, independent sites to be served from a single codebase.",
+    "html": [
+      "script[src*='sites\\/(?!default|all).*\\/files']",
+      "img[src*='sites\\/(?!default|all).*\\/files']",
+      "img[data-src*='sites\\/(?!default|all).*\\/files']",
+      "link[href*='sites\\/(?!default|all).*\\/files']"
+    ],
     "icon": "Drupal.svg",
     "implies": "Drupal",
     "oss": true,


### PR DESCRIPTION
Multisite detection was failing on known multisites, expanded detection to other assets.