### PR TITLE
Creating submit github action

### DIFF
--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -1,0 +1,28 @@
+name: "submit"
+on: 
+  workflow_dispatch:
+
+jobs:
+  build: 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.2
+        with:
+          node-version: '14'
+      - name: Restore npm cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm install
+      - name: Build package
+        run: npm run build
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          artifact: ./build/webextension.zip
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ tags.*
 .idea
 /nbproject/private/
 src/out.json
+
+keys.json


### PR DESCRIPTION
Hi @AliasIO,

Thanks for making wappalyzer - this extension is awesome! I was looking for some way to contribute, and thought that maybe an automated submission pipeline for the zip archive could be helpful. The github action in this PR is made to be run manually from the github action tab. The only thing you would need to create is a `SUBMIT_KEYS` github repository secret. 

This secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/main/keys.schema.json).

Here's a sample key:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/main/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "extId": "123",
    "apiKey": "abcd",
    "apiSecret": "efgh"
  }
}

```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)