### PR TITLE
Move django_language cookie detection from Django CMS to Django

### DIFF
--- a/src/technologies/d.json
+++ b/src/technologies/d.json
@@ -736,6 +736,9 @@
     "html": "(?:powered by <a[^>]+>Django ?([\\d.]+)?<\\/a>|<input[^>]*name=[\"']csrfmiddlewaretoken[\"'][^>]*>)\\;version:\\1",
     "icon": "Django.png",
     "implies": "Python",
+    "cookies": {
+      "django_language": ""
+    },
     "js": {
       "__admin_media_prefix__": "",
       "django": ""
@@ -747,9 +750,6 @@
     "cats": [
       1
     ],
-    "cookies": {
-      "django_language": ""
-    },
     "description": "Django CMS is a free and open source content management system platform for publishing content on the World Wide Web and intranets.",
     "icon": "Django CMS.png",
     "implies": [


### PR DESCRIPTION
Spotted because I was reviewing two sites (https://vb-tpb.ch/fr/voyager/arrets/, https://sla.gs1.events/fr/) I had been told were built with Wagtail, but Wappalyzer reports them as both Wagtail and Django CMS (which would technically be possible, but very odd).

Looking at Wappalyzer’s checks, this is because of the `django_language` cookie detection. `django_language` is the default cookie name (see [Django docs](https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-LANGUAGE_COOKIE_NAME) for it) for all Django projects that use Django’s translation support, it’s not specific to Django CMS.